### PR TITLE
feat(auth): add next-auth models and rename account

### DIFF
--- a/app/api/pluggy/sync/route.ts
+++ b/app/api/pluggy/sync/route.ts
@@ -14,7 +14,7 @@ export async function POST(req: NextRequest) {
   const accResp = await listAccounts({ itemId })
   const accounts = accResp.results || accResp
   for (const acc of accounts) {
-    await prisma.account.upsert({
+    await prisma.bankAccount.upsert({
       where: { id: acc.id },
       update: {
         userId: user.id,
@@ -82,7 +82,7 @@ export async function POST(req: NextRequest) {
 export async function GET(req: NextRequest) {
   const user = await getUserFromRequest(req)
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const accounts = await prisma.account.findMany({ where: { userId: user.id } })
+  const accounts = await prisma.bankAccount.findMany({ where: { userId: user.id } })
   const transactions = await prisma.transaction.findMany({
     where: { userId: user.id },
     orderBy: { date: 'desc' },

--- a/prisma/migrations/20250915020243_add_next_auth_models/migration.sql
+++ b/prisma/migrations/20250915020243_add_next_auth_models/migration.sql
@@ -1,0 +1,211 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `balance` on the `Account` table. All the data in the column will be lost.
+  - You are about to drop the column `createdAt` on the `Account` table. All the data in the column will be lost.
+  - You are about to drop the column `currency` on the `Account` table. All the data in the column will be lost.
+  - You are about to drop the column `dataEnc` on the `Account` table. All the data in the column will be lost.
+  - You are about to drop the column `mask` on the `Account` table. All the data in the column will be lost.
+  - You are about to drop the column `name` on the `Account` table. All the data in the column will be lost.
+  - You are about to drop the column `providerItem` on the `Account` table. All the data in the column will be lost.
+  - You are about to drop the column `updatedAt` on the `Account` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[provider,providerAccountId]` on the table `Account` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `providerAccountId` to the `Account` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `type` to the `Account` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Account" DROP CONSTRAINT "Account_userId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Transaction" DROP CONSTRAINT "Transaction_accountId_fkey";
+
+-- AlterTable
+ALTER TABLE "Account" DROP COLUMN "balance",
+DROP COLUMN "createdAt",
+DROP COLUMN "currency",
+DROP COLUMN "dataEnc",
+DROP COLUMN "mask",
+DROP COLUMN "name",
+DROP COLUMN "providerItem",
+DROP COLUMN "updatedAt",
+ADD COLUMN     "access_token" TEXT,
+ADD COLUMN     "expires_at" INTEGER,
+ADD COLUMN     "id_token" TEXT,
+ADD COLUMN     "providerAccountId" TEXT NOT NULL,
+ADD COLUMN     "refresh_token" TEXT,
+ADD COLUMN     "scope" TEXT,
+ADD COLUMN     "session_state" TEXT,
+ADD COLUMN     "token_type" TEXT,
+ADD COLUMN     "type" TEXT NOT NULL;
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "emailVerified" TIMESTAMP(3),
+ADD COLUMN     "image" TEXT;
+
+-- CreateTable
+CREATE TABLE "BankAccount" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "providerItem" TEXT,
+    "name" TEXT NOT NULL,
+    "currency" TEXT NOT NULL,
+    "balance" DECIMAL(18,2) NOT NULL,
+    "mask" TEXT,
+    "dataEnc" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BankAccount_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Budget" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "totalAmount" DECIMAL(18,2) NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'BRL',
+    "period" TEXT NOT NULL,
+    "startDate" TIMESTAMP(3) NOT NULL,
+    "endDate" TIMESTAMP(3) NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Budget_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BudgetItem" (
+    "id" TEXT NOT NULL,
+    "budgetId" TEXT NOT NULL,
+    "accountId" TEXT,
+    "category" TEXT NOT NULL,
+    "amount" DECIMAL(18,2) NOT NULL,
+    "spent" DECIMAL(18,2) NOT NULL DEFAULT 0,
+    "currency" TEXT NOT NULL DEFAULT 'BRL',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "BudgetItem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Goal" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "targetAmount" DECIMAL(18,2) NOT NULL,
+    "currentAmount" DECIMAL(18,2) NOT NULL DEFAULT 0,
+    "currency" TEXT NOT NULL DEFAULT 'BRL',
+    "targetDate" TIMESTAMP(3) NOT NULL,
+    "isCompleted" BOOLEAN NOT NULL DEFAULT false,
+    "category" TEXT,
+    "priority" TEXT NOT NULL DEFAULT 'medium',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Goal_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Subscription" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "amount" DECIMAL(18,2) NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'BRL',
+    "billingCycle" TEXT NOT NULL,
+    "nextBilling" TIMESTAMP(3) NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "category" TEXT,
+    "autoRenew" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Subscription_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Loan" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "amount" DECIMAL(18,2) NOT NULL,
+    "currency" TEXT NOT NULL DEFAULT 'BRL',
+    "lenderName" TEXT NOT NULL,
+    "lenderContact" TEXT,
+    "type" TEXT NOT NULL,
+    "interestRate" DECIMAL(5,2),
+    "dueDate" TIMESTAMP(3),
+    "isPaid" BOOLEAN NOT NULL DEFAULT false,
+    "paidAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Loan_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Session" (
+    "id" TEXT NOT NULL,
+    "sessionToken" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "VerificationToken" (
+    "identifier" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires" TIMESTAMP(3) NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Session_sessionToken_key" ON "Session"("sessionToken");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VerificationToken_token_key" ON "VerificationToken"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "VerificationToken_identifier_token_key" ON "VerificationToken"("identifier", "token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account"("provider", "providerAccountId");
+
+-- AddForeignKey
+ALTER TABLE "BankAccount" ADD CONSTRAINT "BankAccount_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Transaction" ADD CONSTRAINT "Transaction_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "BankAccount"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Budget" ADD CONSTRAINT "Budget_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BudgetItem" ADD CONSTRAINT "BudgetItem_budgetId_fkey" FOREIGN KEY ("budgetId") REFERENCES "Budget"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "BudgetItem" ADD CONSTRAINT "BudgetItem_accountId_fkey" FOREIGN KEY ("accountId") REFERENCES "BankAccount"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Goal" ADD CONSTRAINT "Goal_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Subscription" ADD CONSTRAINT "Subscription_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Loan" ADD CONSTRAINT "Loan_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Account" ADD CONSTRAINT "Account_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Session" ADD CONSTRAINT "Session_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,21 +8,25 @@ datasource db {
 }
 
 model User {
-  id           String         @id @default(cuid())
-  email        String         @unique
-  name         String?
-  passwordHash String
-  twoFASecret  String?
-  createdAt    DateTime       @default(now())
-  updatedAt    DateTime       @updatedAt
-  accounts     Account[]
-  budgets      Budget[]
-  goals        Goal[]
-  subscriptions Subscription[]
-  loans        Loan[]
+  id             String            @id @default(cuid())
+  email          String            @unique
+  name           String?
+  passwordHash   String
+  twoFASecret    String?
+  emailVerified  DateTime?
+  image          String?
+  createdAt      DateTime          @default(now())
+  updatedAt      DateTime          @updatedAt
+  bankAccounts   BankAccount[]
+  budgets        Budget[]
+  goals          Goal[]
+  subscriptions  Subscription[]
+  loans          Loan[]
+  accounts       Account[]
+  sessions       Session[]
 }
 
-model Account {
+model BankAccount {
   id           String        @id @default(cuid())
   userId       String
   user         User          @relation(fields: [userId], references: [id])
@@ -40,9 +44,9 @@ model Account {
 }
 
 model Transaction {
-  id          String   @id @default(cuid())
-  accountId   String
-  account     Account  @relation(fields: [accountId], references: [id])
+  id            String       @id @default(cuid())
+  accountId     String
+  bankAccount   BankAccount  @relation(fields: [accountId], references: [id])
   userId      String
   description String
   category    String?
@@ -71,17 +75,17 @@ model Budget {
 }
 
 model BudgetItem {
-  id         String  @id @default(cuid())
-  budgetId   String
-  budget     Budget  @relation(fields: [budgetId], references: [id], onDelete: Cascade)
-  accountId  String?
-  account    Account? @relation(fields: [accountId], references: [id])
-  category   String
-  amount     Decimal @db.Decimal(18, 2)
-  spent      Decimal @db.Decimal(18, 2) @default(0)
-  currency   String  @default("BRL")
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  id           String       @id @default(cuid())
+  budgetId     String
+  budget       Budget       @relation(fields: [budgetId], references: [id], onDelete: Cascade)
+  accountId    String?
+  bankAccount  BankAccount? @relation(fields: [accountId], references: [id])
+  category     String
+  amount       Decimal      @db.Decimal(18, 2)
+  spent        Decimal      @db.Decimal(18, 2) @default(0)
+  currency     String       @default("BRL")
+  createdAt    DateTime     @default(now())
+  updatedAt    DateTime     @updatedAt
 }
 
 model Goal {
@@ -135,4 +139,38 @@ model Loan {
   paidAt        DateTime?
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
+}
+
+model Account {
+  id                String   @id @default(cuid())
+  userId            String
+  type              String
+  provider          String
+  providerAccountId String
+  refresh_token     String?  @db.Text
+  access_token      String?  @db.Text
+  expires_at        Int?
+  token_type        String?
+  scope             String?
+  id_token          String?  @db.Text
+  session_state     String?
+  user              User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
+}
+
+model Session {
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+}
+
+model VerificationToken {
+  identifier String
+  token      String   @unique
+  expires    DateTime
+
+  @@unique([identifier, token])
 }


### PR DESCRIPTION
## Summary
- add NextAuth Account, Session and VerificationToken models
- rename financial Account model to BankAccount and update relations
- adjust Pluggy sync API to use BankAccount

## Testing
- `npx prisma migrate dev --name add-next-auth-models`
- `npx prisma generate`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c77313190c832f9ad7eac63df511f0