### PR TITLE
Protect pages with session middleware

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,7 @@
 'use client'
 import { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
 import {
   PieChart,
   Pie,
@@ -25,6 +27,8 @@ export default function Dashboard() {
   const [subscriptions, setSubscriptions] = useState<any[]>([])
   const [loans, setLoans] = useState<any[]>([])
   const [sdkReady, setSdkReady] = useState(false)
+  const { status } = useSession()
+  const router = useRouter()
 
   async function loadData() {
     try {
@@ -69,7 +73,15 @@ export default function Dashboard() {
     }
   }
 
-  useEffect(() => { loadData() }, [])
+  useEffect(() => {
+    if (status === 'unauthenticated') {
+      router.push('/login')
+      return
+    }
+    if (status === 'authenticated') {
+      loadData()
+    }
+  }, [status, router])
 
   useEffect(() => {
     if ((window as any).PluggyConnect) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css'
 import { Inter } from 'next/font/google'
 import Navbar from '@/components/navbar'
+import Providers from './providers'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -11,8 +12,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <script src="https://connect.pluggy.ai/sdk.js" async></script>
       </head>
       <body className={`${inter.className} bg-gradient-to-br from-slate-900 to-slate-800 text-slate-100`}>
-        <Navbar />
-        <main className="max-w-6xl mx-auto p-4">{children}</main>
+        <Providers>
+          <Navbar />
+          <main className="max-w-6xl mx-auto p-4">{children}</main>
+        </Providers>
       </body>
     </html>
   )

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { SessionProvider } from 'next-auth/react'
+import type { ReactNode } from 'react'
+
+export default function Providers({ children }: { children: ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,38 +1,19 @@
 'use client'
 
 import Link from 'next/link'
-import { useEffect, useState } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { motion } from 'framer-motion'
 import { LiquidButton } from './ui/liquid-button'
+import { useSession, signOut } from 'next-auth/react'
 
 export default function Navbar() {
-  const [authenticated, setAuthenticated] = useState(false)
+  const { data: session } = useSession()
+  const authenticated = !!session
   const pathname = usePathname()
   const router = useRouter()
 
-  async function checkAuth() {
-    try {
-      const res = await fetch('/api/auth/me', { cache: 'no-store' })
-      if (res.ok) {
-        const data = await res.json()
-        setAuthenticated(data.authenticated)
-      } else {
-        setAuthenticated(false)
-      }
-    } catch {
-      setAuthenticated(false)
-    }
-  }
-
-  useEffect(() => {
-    checkAuth()
-  }, [pathname])
-
-  async function handleLogout() {
-    await fetch('/api/auth/logout', { method: 'POST' })
-    setAuthenticated(false)
-    router.refresh()
+  const handleLogout = async () => {
+    await signOut({ callbackUrl: '/' })
   }
 
   const navItems = authenticated ? [

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+import { getToken } from 'next-auth/jwt'
+
+export async function middleware(req: NextRequest) {
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
+  const { pathname } = req.nextUrl
+
+  // Allow requests to next internal, api routes, or login/register pages
+  const isAuthPage = pathname.startsWith('/login') || pathname.startsWith('/register')
+  if (!token && !isAuthPage && !pathname.startsWith('/api') && !pathname.startsWith('/_next')) {
+    const url = req.nextUrl.clone()
+    url.pathname = '/login'
+    return NextResponse.redirect(url)
+  }
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico).*)'],
+}


### PR DESCRIPTION
## Summary
- add middleware to redirect unauthenticated users to login
- wrap app with SessionProvider so components can read session
- read session with `useSession` in navbar and dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c776b2eb68832fbb625fbbb2e541da