### PR TITLE
chore: validate numeric fields

### DIFF
--- a/app/api/budget/[id]/route.ts
+++ b/app/api/budget/[id]/route.ts
@@ -13,6 +13,29 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     const data = await request.json()
     const { name, totalAmount, items } = data
 
+    let totalAmountNumber: number | undefined
+    if (totalAmount !== undefined) {
+      totalAmountNumber = Number(totalAmount)
+      if (Number.isNaN(totalAmountNumber)) {
+        return NextResponse.json({ error: 'Campo totalAmount inválido' }, { status: 400 })
+      }
+    }
+
+    if (items && Array.isArray(items)) {
+      for (const item of items) {
+        const itemAmount = Number(item.amount)
+        if (Number.isNaN(itemAmount)) {
+          return NextResponse.json({ error: 'Campo amount inválido' }, { status: 400 })
+        }
+        if (item.spent !== undefined) {
+          const itemSpent = Number(item.spent)
+          if (Number.isNaN(itemSpent)) {
+            return NextResponse.json({ error: 'Campo spent inválido' }, { status: 400 })
+          }
+        }
+      }
+    }
+
     // Verify budget belongs to user
     const existingBudget = await prisma.budget.findFirst({
       where: { id, userId: session.user.id },
@@ -30,7 +53,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
         where: { id },
         data: {
           name: name || existingBudget.name,
-          totalAmount: totalAmount ? Number(totalAmount) : existingBudget.totalAmount
+          totalAmount: totalAmount ? totalAmountNumber! : existingBudget.totalAmount
         }
       })
 

--- a/app/api/budget/route.ts
+++ b/app/api/budget/route.ts
@@ -50,12 +50,26 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Campos obrigatórios não preenchidos' }, { status: 400 })
     }
 
+    const totalAmountNumber = Number(totalAmount)
+    if (Number.isNaN(totalAmountNumber)) {
+      return NextResponse.json({ error: 'Campo totalAmount inválido' }, { status: 400 })
+    }
+
+    if (items && Array.isArray(items)) {
+      for (const item of items) {
+        const itemAmount = Number(item.amount)
+        if (Number.isNaN(itemAmount)) {
+          return NextResponse.json({ error: 'Campo amount inválido' }, { status: 400 })
+        }
+      }
+    }
+
     // Create budget
     const budget = await prisma.budget.create({
       data: {
         userId: session.user.id,
         name,
-        totalAmount: Number(totalAmount),
+        totalAmount: totalAmountNumber,
         currency: currency || 'BRL',
         period,
         startDate: new Date(startDate),

--- a/app/api/goals/[id]/route.ts
+++ b/app/api/goals/[id]/route.ts
@@ -12,6 +12,22 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     const id = params.id
     const data = await request.json()
 
+    let targetAmountNumber: number | undefined
+    if (data.targetAmount !== undefined) {
+      targetAmountNumber = Number(data.targetAmount)
+      if (Number.isNaN(targetAmountNumber)) {
+        return NextResponse.json({ error: 'Campo targetAmount inválido' }, { status: 400 })
+      }
+    }
+
+    let currentAmountNumber: number | undefined
+    if (data.currentAmount !== undefined) {
+      currentAmountNumber = Number(data.currentAmount)
+      if (Number.isNaN(currentAmountNumber)) {
+        return NextResponse.json({ error: 'Campo currentAmount inválido' }, { status: 400 })
+      }
+    }
+
     // Verify goal belongs to user
     const existingGoal = await prisma.goal.findFirst({
       where: { id, userId: session.user.id }
@@ -26,8 +42,8 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
       where: { id },
       data: {
         ...data,
-        targetAmount: data.targetAmount ? Number(data.targetAmount) : undefined,
-        currentAmount: data.currentAmount ? Number(data.currentAmount) : undefined,
+        targetAmount: targetAmountNumber,
+        currentAmount: currentAmountNumber,
         targetDate: data.targetDate ? new Date(data.targetDate) : undefined
       }
     })

--- a/app/api/goals/route.ts
+++ b/app/api/goals/route.ts
@@ -43,13 +43,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Campos obrigatórios não preenchidos' }, { status: 400 })
     }
 
+    const targetAmountNumber = Number(targetAmount)
+    if (Number.isNaN(targetAmountNumber)) {
+      return NextResponse.json({ error: 'Campo targetAmount inválido' }, { status: 400 })
+    }
+
     // Create goal
     const goal = await prisma.goal.create({
       data: {
         userId: session.user.id,
         title,
         description,
-        targetAmount: Number(targetAmount),
+        targetAmount: targetAmountNumber,
         currency: currency || 'BRL',
         targetDate: new Date(targetDate),
         category,

--- a/app/api/loans/[id]/route.ts
+++ b/app/api/loans/[id]/route.ts
@@ -12,6 +12,22 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     const id = params.id
     const data = await request.json()
 
+    let amountNumber: number | undefined
+    if (data.amount !== undefined) {
+      amountNumber = Number(data.amount)
+      if (Number.isNaN(amountNumber)) {
+        return NextResponse.json({ error: 'Campo amount inválido' }, { status: 400 })
+      }
+    }
+
+    let interestRateNumber: number | undefined
+    if (data.interestRate !== undefined) {
+      interestRateNumber = Number(data.interestRate)
+      if (Number.isNaN(interestRateNumber)) {
+        return NextResponse.json({ error: 'Campo interestRate inválido' }, { status: 400 })
+      }
+    }
+
     // Verify loan belongs to user
     const existingLoan = await prisma.loan.findFirst({
       where: { id, userId: session.user.id }
@@ -26,8 +42,8 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
       where: { id },
       data: {
         ...data,
-        amount: data.amount ? Number(data.amount) : undefined,
-        interestRate: data.interestRate ? Number(data.interestRate) : undefined,
+        amount: amountNumber,
+        interestRate: interestRateNumber,
         dueDate: data.dueDate ? new Date(data.dueDate) : undefined,
         paidAt: data.isPaid && !existingLoan.isPaid ? new Date() : data.isPaid === false ? null : undefined
       }

--- a/app/api/loans/route.ts
+++ b/app/api/loans/route.ts
@@ -48,18 +48,31 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Tipo de empréstimo inválido' }, { status: 400 })
     }
 
+    const amountNumber = Number(amount)
+    if (Number.isNaN(amountNumber)) {
+      return NextResponse.json({ error: 'Campo amount inválido' }, { status: 400 })
+    }
+
+    let interestRateNumber: number | null = null
+    if (interestRate !== undefined && interestRate !== null) {
+      interestRateNumber = Number(interestRate)
+      if (Number.isNaN(interestRateNumber)) {
+        return NextResponse.json({ error: 'Campo interestRate inválido' }, { status: 400 })
+      }
+    }
+
     // Create loan
     const loan = await prisma.loan.create({
       data: {
         userId: session.user.id,
         title,
         description,
-        amount: Number(amount),
+        amount: amountNumber,
         currency: currency || 'BRL',
         lenderName,
         lenderContact,
         type,
-        interestRate: interestRate ? Number(interestRate) : null,
+        interestRate: interestRateNumber,
         dueDate: dueDate ? new Date(dueDate) : null
       }
     })

--- a/app/api/subscriptions/[id]/route.ts
+++ b/app/api/subscriptions/[id]/route.ts
@@ -12,6 +12,14 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     const id = params.id
     const data = await request.json()
 
+    let amountNumber: number | undefined
+    if (data.amount !== undefined) {
+      amountNumber = Number(data.amount)
+      if (Number.isNaN(amountNumber)) {
+        return NextResponse.json({ error: 'Campo amount inválido' }, { status: 400 })
+      }
+    }
+
     // Verify subscription belongs to user
     const existingSubscription = await prisma.subscription.findFirst({
       where: { id, userId: session.user.id }
@@ -26,7 +34,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
       where: { id },
       data: {
         ...data,
-        amount: data.amount ? Number(data.amount) : undefined,
+        amount: amountNumber,
         nextBilling: data.nextBilling ? new Date(data.nextBilling) : undefined
       }
     })

--- a/app/api/subscriptions/route.ts
+++ b/app/api/subscriptions/route.ts
@@ -42,13 +42,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Campos obrigatórios não preenchidos' }, { status: 400 })
     }
 
+    const amountNumber = Number(amount)
+    if (Number.isNaN(amountNumber)) {
+      return NextResponse.json({ error: 'Campo amount inválido' }, { status: 400 })
+    }
+
     // Create subscription
     const subscription = await prisma.subscription.create({
       data: {
         userId: session.user.id,
         name,
         description,
-        amount: Number(amount),
+        amount: amountNumber,
         currency: currency || 'BRL',
         billingCycle,
         nextBilling: new Date(nextBilling),


### PR DESCRIPTION
## Summary
- validate amounts in budget routes and items
- ensure subscription endpoints reject invalid amounts
- add goal and loan numeric checks with 400 responses

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: ENCRYPTION_KEY_BASE64 inválido)*

------
https://chatgpt.com/codex/tasks/task_e_68c7821a6a4c832f87552d424e9c2ac3