### PR TITLE
Simplify tsconfig include

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,13 +33,7 @@
     ]
   },
   "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    "types/**/*.d.ts",
-    "types/**/*.d.ts",
-    "types/**/*.d.ts",
-    ".next/types/**/*.ts"
+    "types/**/*.d.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- limit `tsconfig.json` includes to declaration files only

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: ENCRYPTION_KEY_BASE64 not defined)


------
https://chatgpt.com/codex/tasks/task_e_68c785d3f558832f80b4515a11364688