### PR TITLE
chore: update axios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "dependencies": {
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^5.17.0",
-        "axios": "^1.7.2",
+        "axios": "^1.12.2",
         "framer-motion": "^11.0.0",
         "next": "14.2.5",
         "next-auth": "^4.24.11",
@@ -1927,9 +1927,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
-      "integrity": "sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^5.17.0",
-    "axios": "^1.7.2",
+    "axios": "^1.12.2",
     "framer-motion": "^11.0.0",
     "next": "14.2.5",
     "next-auth": "^4.24.11",


### PR DESCRIPTION
## Summary
- bump axios to ^1.12.2
- regenerate package-lock.json

## Testing
- `npm test` (fails: Missing script: "test")
- `npm audit --offline`


------
https://chatgpt.com/codex/tasks/task_e_68c7886690dc832f926c5567a1b44c8c