### PR TITLE
feat: integrate theme tokens and animate plugin

### DIFF
--- a/components/ui/liquid-button.tsx
+++ b/components/ui/liquid-button.tsx
@@ -14,13 +14,18 @@ interface LiquidButtonProps {
 
 export const LiquidButton = React.forwardRef<HTMLButtonElement, LiquidButtonProps>(
   ({ className = '', variant = 'primary', size = 'md', glowColor, children, onClick, disabled, type = 'button' }, ref) => {
-    const baseClasses = 'glass-effect font-medium transition-all duration-300 relative overflow-hidden group disabled:opacity-50 disabled:cursor-not-allowed'
-    
+    const baseClasses =
+      'bg-card-glass/60 border border-card-border/50 backdrop-blur-glass font-medium transition-all duration-300 relative overflow-hidden group disabled:opacity-50 disabled:cursor-not-allowed'
+
     const variantClasses = {
-      primary: 'bg-gradient-to-r from-blue-500/30 to-purple-600/30 hover:from-blue-500/40 hover:to-purple-600/40 text-white border-blue-400/30',
-      secondary: 'bg-white/10 hover:bg-white/20 text-slate-200 border-white/20',
-      outline: 'bg-transparent hover:bg-white/10 text-slate-300 border-white/30',
-      ghost: 'bg-transparent hover:bg-white/5 text-slate-300 border-transparent'
+      primary:
+        'bg-primary text-primary-foreground hover:bg-primary/90 border-primary',
+      secondary:
+        'bg-secondary text-secondary-foreground hover:bg-secondary-hover border-secondary',
+      outline:
+        'bg-transparent hover:bg-accent/20 text-foreground border-border',
+      ghost:
+        'bg-transparent hover:bg-accent/10 text-foreground border-transparent',
     }
     
     const sizeClasses = {
@@ -46,7 +51,7 @@ export const LiquidButton = React.forwardRef<HTMLButtonElement, LiquidButtonProp
         type={type}
       >
         {/* Animated background glow on hover */}
-        <div className="absolute inset-0 bg-gradient-to-r from-blue-400/0 via-blue-400/20 to-purple-600/0 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+        <div className="absolute inset-0 bg-gradient-to-r from-primary/0 via-primary-glow/20 to-primary/0 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
         <span className="relative z-10">{children}</span>
       </motion.button>
     )

--- a/components/ui/liquid-card.tsx
+++ b/components/ui/liquid-card.tsx
@@ -12,11 +12,12 @@ interface LiquidCardProps {
 
 export const LiquidCard = React.forwardRef<HTMLDivElement, LiquidCardProps>(
   ({ className = '', style, variant = 'default', glowColor, children, onClick }, ref) => {
-    const baseClasses = 'glass-effect rounded-3xl p-6 relative overflow-hidden'
+    const baseClasses =
+      'bg-card-glass/60 border border-card-border/50 backdrop-blur-glass rounded-3xl p-6 relative overflow-hidden'
     const variantClasses = {
       default: '',
-      hoverable: 'glass-hover cursor-pointer',
-      interactive: 'glass-hover cursor-pointer'
+      hoverable: 'cursor-pointer transition-colors hover:bg-card-glass/70',
+      interactive: 'cursor-pointer transition-colors hover:bg-card-glass/70',
     }
 
     return (
@@ -38,7 +39,7 @@ export const LiquidCard = React.forwardRef<HTMLDivElement, LiquidCardProps>(
       >
         {/* Subtle animated background pattern */}
         <div className="absolute inset-0 opacity-20 pointer-events-none">
-          <div className="absolute -top-24 -right-24 w-48 h-48 bg-gradient-to-br from-blue-400/30 to-purple-600/30 rounded-full blur-3xl floating-animation" />
+          <div className="absolute -top-24 -right-24 w-48 h-48 bg-gradient-to-br from-primary/30 to-primary-glow/30 rounded-full blur-3xl animate-float" />
         </div>
         <div className="relative z-10">
           {children}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/nodemailer": "^7.0.1",
         "@types/react": "^19.1.13",
         "tailwindcss": "^3.4.10",
+        "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.5.4"
       }
     },
@@ -3931,6 +3932,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-animate": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+      "integrity": "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
       }
     },
     "node_modules/tailwindcss/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/nodemailer": "^7.0.1",
     "@types/react": "^19.1.13",
     "tailwindcss": "^3.4.10",
+    "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.5.4"
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,7 +2,12 @@ import type { Config } from 'tailwindcss'
 
 const config: Config = {
   darkMode: ['class'],
-  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  content: [
+    './pages/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+    './app/**/*.{ts,tsx}',
+    './src/**/*.{ts,tsx}',
+  ],
   theme: {
     extend: {
       colors: {
@@ -95,7 +100,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [require('tailwindcss-animate')],
 }
 
 export default config


### PR DESCRIPTION
## Summary
- expand Tailwind paths, map design tokens and enable tailwindcss-animate
- refactor liquid button and card to use theme tokens
- add tailwindcss-animate dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c78ac7a2ac832f9144e095716a9aa0