### PR TITLE
feat: enhance landing page with CTA

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,23 @@
+"use client"
+
+import Link from 'next/link'
+import { LiquidCard } from '@/components/ui/liquid-card'
+import { LiquidButton } from '@/components/ui/liquid-button'
+
 export default function Home() {
   return (
-    <div className="text-center mt-24">
-      <h1 className="text-5xl font-bold mb-4">Financeito</h1>
-      <p className="opacity-80">Seu centro de finanças pessoais com Open Finance.</p>
+    <div className="mt-24 flex justify-center">
+      <LiquidCard variant="hoverable" className="text-center">
+        <h1 className="text-5xl font-bold mb-4 text-gradient-primary glow-primary">
+          Financeito
+        </h1>
+        <p className="opacity-80">Seu centro de finanças pessoais com Open Finance.</p>
+        <Link href="/dashboard">
+          <LiquidButton variant="primary" className="mt-6">
+            Acessar Dashboard
+          </LiquidButton>
+        </Link>
+      </LiquidCard>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- wrap landing content in a hoverable LiquidCard and highlight title with gradient and glow
- add primary LiquidButton CTA leading to dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c78cf829b8832f91e7c6b408d0221c