### PR TITLE
feat: introduce LiquidInput component

### DIFF
--- a/components/forms/budget-form.tsx
+++ b/components/forms/budget-form.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
+import { LiquidInput } from '@/components/ui/liquid-input'
 import { Budget, BudgetItem } from '@/types/budget'
 
 interface BudgetFormProps {
@@ -92,13 +93,13 @@ export function BudgetForm({ budget, onSubmit, onCancel, loading }: BudgetFormPr
               <label className="block text-sm font-medium text-slate-300 mb-2">
                 Nome do Orçamento
               </label>
-              <input
+              <LiquidInput
                 type="text"
                 value={formData.name}
                 onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
-                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 placeholder="Ex: Orçamento Dezembro 2024"
                 required
+                className="focus:ring-2 focus:ring-blue-500"
               />
             </div>
 
@@ -137,26 +138,26 @@ export function BudgetForm({ budget, onSubmit, onCancel, loading }: BudgetFormPr
                     <div className="grid md:grid-cols-3 gap-3">
                       <div>
                         <label className="block text-xs text-slate-400 mb-1">Nome</label>
-                        <input
+                        <LiquidInput
                           type="text"
                           value={item.name}
                           onChange={(e) => updateItem(index, 'name', e.target.value)}
-                          className="w-full px-3 py-2 bg-slate-600/50 border border-slate-500 rounded text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-blue-500"
                           placeholder="Ex: Alimentação"
                           required
+                          className="focus:ring-1 focus:ring-blue-500"
                         />
                       </div>
 
                       <div>
                         <label className="block text-xs text-slate-400 mb-1">Valor (R$)</label>
-                        <input
+                        <LiquidInput
                           type="number"
                           step="0.01"
                           value={item.amount}
                           onChange={(e) => updateItem(index, 'amount', parseFloat(e.target.value) || 0)}
-                          className="w-full px-3 py-2 bg-slate-600/50 border border-slate-500 rounded text-white placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-blue-500"
                           placeholder="0,00"
                           required
+                          className="focus:ring-1 focus:ring-blue-500"
                         />
                       </div>
 
@@ -188,13 +189,13 @@ export function BudgetForm({ budget, onSubmit, onCancel, loading }: BudgetFormPr
               <label className="block text-sm font-medium text-slate-300 mb-2">
                 Valor Total (R$)
               </label>
-              <input
+              <LiquidInput
                 type="number"
                 step="0.01"
                 value={formData.totalAmount}
                 onChange={(e) => setFormData(prev => ({ ...prev, totalAmount: parseFloat(e.target.value) || 0 }))}
-                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
                 placeholder="Deixe vazio para calcular automaticamente"
+                className="focus:ring-2 focus:ring-blue-500"
               />
               <p className="text-xs text-slate-400 mt-1">
                 Total calculado dos itens: R$ {formData.items.reduce((sum, item) => sum + item.amount, 0).toFixed(2)}

--- a/components/forms/goal-form.tsx
+++ b/components/forms/goal-form.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
+import { LiquidInput } from '@/components/ui/liquid-input'
 
 interface Goal {
   id?: string
@@ -80,13 +81,13 @@ export function GoalForm({ goal, onSubmit, onCancel, loading }: GoalFormProps) {
               <label className="block text-sm font-medium text-slate-300 mb-2">
                 Título da Meta *
               </label>
-              <input
+              <LiquidInput
                 type="text"
                 value={formData.title}
                 onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
-                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-green-500"
                 placeholder="Ex: Comprar um carro"
                 required
+                className="focus:ring-2 focus:ring-green-500"
               />
             </div>
 
@@ -110,14 +111,14 @@ export function GoalForm({ goal, onSubmit, onCancel, loading }: GoalFormProps) {
                 <label className="block text-sm font-medium text-slate-300 mb-2">
                   Valor da Meta *
                 </label>
-                <input
+                <LiquidInput
                   type="number"
                   step="0.01"
                   value={formData.targetAmount}
                   onChange={(e) => setFormData(prev => ({ ...prev, targetAmount: parseFloat(e.target.value) || 0 }))}
-                  className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-green-500"
                   placeholder="0,00"
                   required
+                  className="focus:ring-2 focus:ring-green-500"
                 />
               </div>
 
@@ -142,13 +143,13 @@ export function GoalForm({ goal, onSubmit, onCancel, loading }: GoalFormProps) {
               <label className="block text-sm font-medium text-slate-300 mb-2">
                 Valor Atual (já poupado)
               </label>
-              <input
+              <LiquidInput
                 type="number"
                 step="0.01"
                 value={formData.currentAmount}
                 onChange={(e) => setFormData(prev => ({ ...prev, currentAmount: parseFloat(e.target.value) || 0 }))}
-                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-green-500"
                 placeholder="0,00"
+                className="focus:ring-2 focus:ring-green-500"
               />
               {formData.targetAmount > 0 && (
                 <div className="mt-2">
@@ -171,12 +172,12 @@ export function GoalForm({ goal, onSubmit, onCancel, loading }: GoalFormProps) {
               <label className="block text-sm font-medium text-slate-300 mb-2">
                 Data da Meta *
               </label>
-              <input
+              <LiquidInput
                 type="date"
                 value={formData.targetDate}
                 onChange={(e) => setFormData(prev => ({ ...prev, targetDate: e.target.value }))}
-                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-green-500"
                 required
+                className="focus:ring-2 focus:ring-green-500"
               />
             </div>
 

--- a/components/forms/loan-form.tsx
+++ b/components/forms/loan-form.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
+import { LiquidInput } from '@/components/ui/liquid-input'
 
 interface Loan {
   id?: string
@@ -120,13 +121,13 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
               <label className="block text-sm font-medium text-slate-300 mb-2">
                 Título do Empréstimo *
               </label>
-              <input
+              <LiquidInput
                 type="text"
                 value={formData.title}
                 onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
-                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-yellow-500"
                 placeholder={isLending ? "Ex: Empréstimo para João" : "Ex: Empréstimo da Maria"}
                 required
+                className="focus:ring-2 focus:ring-yellow-500"
               />
             </div>
 
@@ -150,14 +151,14 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
                 <label className="block text-sm font-medium text-slate-300 mb-2">
                   Valor *
                 </label>
-                <input
+                <LiquidInput
                   type="number"
                   step="0.01"
                   value={formData.amount}
                   onChange={(e) => setFormData(prev => ({ ...prev, amount: parseFloat(e.target.value) || 0 }))}
-                  className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-yellow-500"
                   placeholder="0,00"
                   required
+                  className="focus:ring-2 focus:ring-yellow-500"
                 />
               </div>
 
@@ -183,13 +184,13 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
                 <label className="block text-sm font-medium text-slate-300 mb-2">
                   {isLending ? 'Nome de quem recebeu *' : 'Nome de quem emprestou *'}
                 </label>
-                <input
+                <LiquidInput
                   type="text"
                   value={formData.lenderName}
                   onChange={(e) => setFormData(prev => ({ ...prev, lenderName: e.target.value }))}
-                  className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-yellow-500"
                   placeholder="Nome completo"
                   required
+                  className="focus:ring-2 focus:ring-yellow-500"
                 />
               </div>
 
@@ -197,12 +198,12 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
                 <label className="block text-sm font-medium text-slate-300 mb-2">
                   Contato
                 </label>
-                <input
+                <LiquidInput
                   type="text"
                   value={formData.lenderContact}
                   onChange={(e) => setFormData(prev => ({ ...prev, lenderContact: e.target.value }))}
-                  className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-yellow-500"
                   placeholder="Telefone ou email"
+                  className="focus:ring-2 focus:ring-yellow-500"
                 />
               </div>
             </div>
@@ -213,13 +214,13 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
                 <label className="block text-sm font-medium text-slate-300 mb-2">
                   Taxa de Juros (% a.a.)
                 </label>
-                <input
+                <LiquidInput
                   type="number"
                   step="0.01"
                   value={formData.interestRate}
                   onChange={(e) => setFormData(prev => ({ ...prev, interestRate: parseFloat(e.target.value) || 0 }))}
-                  className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-yellow-500"
                   placeholder="0,00"
+                  className="focus:ring-2 focus:ring-yellow-500"
                 />
               </div>
 
@@ -227,11 +228,11 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
                 <label className="block text-sm font-medium text-slate-300 mb-2">
                   Data de Vencimento
                 </label>
-                <input
+                <LiquidInput
                   type="date"
                   value={formData.dueDate}
                   onChange={(e) => setFormData(prev => ({ ...prev, dueDate: e.target.value }))}
-                  className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-yellow-500"
+                  className="focus:ring-2 focus:ring-yellow-500"
                 />
               </div>
             </div>

--- a/components/forms/subscription-form.tsx
+++ b/components/forms/subscription-form.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
+import { LiquidInput } from '@/components/ui/liquid-input'
 
 interface Subscription {
   id?: string
@@ -80,13 +81,13 @@ export function SubscriptionForm({ subscription, onSubmit, onCancel, loading }: 
               <label className="block text-sm font-medium text-slate-300 mb-2">
                 Nome do Serviço *
               </label>
-              <input
+              <LiquidInput
                 type="text"
                 value={formData.name}
                 onChange={(e) => setFormData(prev => ({ ...prev, name: e.target.value }))}
-                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
                 placeholder="Ex: Netflix, Spotify, Adobe Creative"
                 required
+                className="focus:ring-2 focus:ring-purple-500"
               />
             </div>
 
@@ -95,12 +96,12 @@ export function SubscriptionForm({ subscription, onSubmit, onCancel, loading }: 
               <label className="block text-sm font-medium text-slate-300 mb-2">
                 Descrição
               </label>
-              <input
+              <LiquidInput
                 type="text"
                 value={formData.description}
                 onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
-                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
                 placeholder="Plano ou detalhes adicionais..."
+                className="focus:ring-2 focus:ring-purple-500"
               />
             </div>
 
@@ -110,14 +111,14 @@ export function SubscriptionForm({ subscription, onSubmit, onCancel, loading }: 
                 <label className="block text-sm font-medium text-slate-300 mb-2">
                   Valor *
                 </label>
-                <input
+                <LiquidInput
                   type="number"
                   step="0.01"
                   value={formData.amount}
                   onChange={(e) => setFormData(prev => ({ ...prev, amount: parseFloat(e.target.value) || 0 }))}
-                  className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
                   placeholder="0,00"
                   required
+                  className="focus:ring-2 focus:ring-purple-500"
                 />
               </div>
 
@@ -163,12 +164,12 @@ export function SubscriptionForm({ subscription, onSubmit, onCancel, loading }: 
               <label className="block text-sm font-medium text-slate-300 mb-2">
                 Próxima Cobrança *
               </label>
-              <input
+              <LiquidInput
                 type="date"
                 value={formData.nextBilling}
                 onChange={(e) => setFormData(prev => ({ ...prev, nextBilling: e.target.value }))}
-                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
                 required
+                className="focus:ring-2 focus:ring-purple-500"
               />
             </div>
 

--- a/components/ui/liquid-input.tsx
+++ b/components/ui/liquid-input.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react'
+
+interface LiquidInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  error?: boolean
+}
+
+export const LiquidInput = React.forwardRef<HTMLInputElement, LiquidInputProps>(
+  ({ className = '', error, ...props }, ref) => {
+    const base = 'bg-card/40 border border-card-border/50 rounded-xl px-3 py-2 w-full text-white placeholder-slate-400 focus:outline-none'
+    const errorClasses = error ? 'border-red-500 focus:ring-red-500' : ''
+
+    return (
+      <input
+        ref={ref}
+        className={`${base} ${errorClasses} ${className}`}
+        {...props}
+      />
+    )
+  }
+)
+
+LiquidInput.displayName = 'LiquidInput'
+
+export default LiquidInput


### PR DESCRIPTION
## Summary
- add reusable `LiquidInput` with shared glassy styling and error state
- refactor budget, goal, loan and subscription forms to use `LiquidInput`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c78dff4c44832f8bfc5df3a1e60eeb