### PR TITLE
refactor: centralize chart colors

### DIFF
--- a/app/budget/page.tsx
+++ b/app/budget/page.tsx
@@ -7,6 +7,7 @@ import { LiquidButton } from '@/components/ui/liquid-button'
 import { BudgetForm } from '@/components/forms/budget-form'
 import { Budget, BudgetItem } from '@/types/budget'
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, BarChart, Bar, XAxis, YAxis } from 'recharts'
+import { chartColors } from '@/lib/theme'
 
 export default function BudgetPage() {
   const [budgets, setBudgets] = useState<Budget[]>([])
@@ -86,7 +87,6 @@ export default function BudgetPage() {
     }
   }
 
-  const colors = ['#8884d8', '#82ca9d', '#ffc658', '#d0ed57', '#8dd1e1', '#ff7c7c']
 
   const activeBudget = budgets.find(b => b.isActive)
 
@@ -175,7 +175,7 @@ export default function BudgetPage() {
                             outerRadius={80}
                           >
                             {activeBudget.items.map((_, i) => (
-                              <Cell key={i} fill={colors[i % colors.length]} />
+                              <Cell key={i} fill={chartColors[i % chartColors.length]} />
                             ))}
                           </Pie>
                           <Tooltip formatter={(value: any, name: any, props: any) => [

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -18,6 +18,7 @@ import {
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
 import { motion } from 'framer-motion'
+import { chartColors } from '@/lib/theme'
 
 export default function Dashboard() {
   const [accounts, setAccounts] = useState<any[]>([])
@@ -125,7 +126,6 @@ export default function Dashboard() {
     connect.init()
   }
 
-  const colors = ['#8884d8', '#82ca9d', '#ffc658', '#d0ed57', '#8dd1e1']
 
   const balanceData = transactions
     .slice()
@@ -158,11 +158,11 @@ export default function Dashboard() {
           <div className="mb-4" style={{ width: '100%', height: 200 }}>
             <ResponsiveContainer>
               <PieChart>
-                <Pie data={accounts} dataKey="balance" nameKey="name" outerRadius={80}>
-                  {accounts.map((_, i) => (
-                    <Cell key={i} fill={colors[i % colors.length]} />
-                  ))}
-                </Pie>
+                  <Pie data={accounts} dataKey="balance" nameKey="name" outerRadius={80}>
+                    {accounts.map((_, i) => (
+                      <Cell key={i} fill={chartColors[i % chartColors.length]} />
+                    ))}
+                  </Pie>
                 <Tooltip />
               </PieChart>
             </ResponsiveContainer>
@@ -191,7 +191,7 @@ export default function Dashboard() {
                 />
                 <YAxis />
                 <Tooltip labelFormatter={(d) => new Date(d).toLocaleDateString()} />
-                <Bar dataKey="amount" fill="#8884d8" />
+                  <Bar dataKey="amount" fill={chartColors[0]} />
               </BarChart>
             </ResponsiveContainer>
           </div>
@@ -212,7 +212,7 @@ export default function Dashboard() {
                 <XAxis dataKey="date" tickFormatter={(d) => new Date(d).toLocaleDateString()} />
                 <YAxis />
                 <Tooltip labelFormatter={(d) => new Date(d).toLocaleDateString()} />
-                <Line type="monotone" dataKey="balance" stroke="#82ca9d" />
+                  <Line type="monotone" dataKey="balance" stroke={chartColors[1]} />
               </LineChart>
             </ResponsiveContainer>
           </div>
@@ -225,11 +225,11 @@ export default function Dashboard() {
           <div style={{ width: '100%', height: 200 }}>
             <ResponsiveContainer>
               <PieChart>
-                <Pie data={categoryData} dataKey="value" nameKey="name" outerRadius={80}>
-                  {categoryData.map((_, i) => (
-                    <Cell key={i} fill={colors[i % colors.length]} />
-                  ))}
-                </Pie>
+                  <Pie data={categoryData} dataKey="value" nameKey="name" outerRadius={80}>
+                    {categoryData.map((_, i) => (
+                      <Cell key={i} fill={chartColors[i % chartColors.length]} />
+                    ))}
+                  </Pie>
                 <Tooltip />
               </PieChart>
             </ResponsiveContainer>

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,0 +1,9 @@
+export const chartColors = [
+  'hsl(var(--color-dashboard))',
+  'hsl(var(--color-accounts))',
+  'hsl(var(--color-transactions))',
+  'hsl(var(--color-investments))',
+  'hsl(var(--color-goals))',
+  'hsl(var(--destructive))',
+]
+


### PR DESCRIPTION
## Summary
- centralize theme-driven chart colors in a new `chartColors` export
- reuse shared `chartColors` in dashboard and budget pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c78f55b974832f846e80a4b375e161