### PR TITLE
Configure TypeScript includes for Next.js sources

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,9 @@
     ]
   },
   "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
     "types/**/*.d.ts"
   ],
   "exclude": [


### PR DESCRIPTION
## Summary
- configure `tsconfig.json` to compile standard Next.js TypeScript patterns
- ensure node_modules remains excluded from compilation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `docker compose build web` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c79a87086c832f88e71a4463533f58