### PR TITLE
Ensure public directory exists during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY package*.json prisma ./
 RUN npm ci || npm install
 COPY . .
+RUN mkdir -p public
 RUN npm run build
 
 # Runtime


### PR DESCRIPTION
## Summary
- ensure `public` directory is created in the Docker build stage to prevent missing static asset directory

## Testing
- `npm test` *(fails: Missing script "test")*
- `docker compose build web` *(fails: command 'compose' not found / Docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_68c79f4f0a14832fa1d57c35905dc1b2