### PR TITLE
feat: add quick access and actions

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -19,6 +19,8 @@ import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
 import { motion } from 'framer-motion'
 import { chartColors } from '@/lib/theme'
+import { QuickAccess, QuickAccessItem } from '@/components/quick-access'
+import { QuickActions, QuickAction } from '@/components/quick-actions'
 
 export default function Dashboard() {
   const [accounts, setAccounts] = useState<any[]>([])
@@ -145,12 +147,47 @@ export default function Dashboard() {
     value,
   }))
 
+  const quickAccessItems: QuickAccessItem[] = [
+    {
+      title: 'Transações',
+      description: 'Histórico de movimentações',
+      href: '/dashboard#transactions',
+    },
+    {
+      title: 'Cartões',
+      description: 'Gerencie seus cartões',
+      href: '/dashboard#cards',
+    },
+    {
+      title: 'Relatórios',
+      description: 'Relatórios detalhados',
+      href: '/dashboard#reports',
+    },
+    { title: 'Orçamentos', description: 'Planeje seus gastos', href: '/budget' },
+    { title: 'Metas', description: 'Acompanhe seus objetivos', href: '/goals' },
+    {
+      title: 'Assinaturas',
+      description: 'Controle suas assinaturas',
+      href: '/subscriptions',
+    },
+    { title: 'Empréstimos', description: 'Gerencie seus empréstimos', href: '/loans' },
+  ]
+
+  const quickActions: QuickAction[] = [
+    { title: 'Conectar Conta', onClick: handleConnect },
+    { title: 'Adicionar Meta', href: '/goals/new' },
+    { title: 'Novo Orçamento', href: '/budget/new' },
+  ]
+
   return (
     <motion.div
-      className="grid md:grid-cols-2 gap-6"
+      className="space-y-6"
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
     >
+      <QuickActions actions={quickActions} />
+      <QuickAccess items={quickAccessItems} />
+      <div className="grid md:grid-cols-2 gap-6">
       <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
         <LiquidCard>
           <h2 className="text-xl font-semibold mb-2">Contas</h2>
@@ -235,6 +272,7 @@ export default function Dashboard() {
           </div>
         </LiquidCard>
       </motion.div>
+      </div>
     </motion.div>
   )
 }

--- a/components/quick-access.tsx
+++ b/components/quick-access.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import Link from 'next/link'
+import { LiquidCard } from '@/components/ui/liquid-card'
+
+export interface QuickAccessItem {
+  title: string
+  description: string
+  href: string
+}
+
+interface QuickAccessProps {
+  items: QuickAccessItem[]
+}
+
+export function QuickAccess({ items }: QuickAccessProps) {
+  return (
+    <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {items.map((item) => (
+        <Link key={item.href} href={item.href} className="block">
+          <LiquidCard variant="hoverable" className="h-full">
+            <h3 className="text-lg font-semibold mb-1">{item.title}</h3>
+            <p className="text-sm text-muted-foreground">{item.description}</p>
+          </LiquidCard>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+export default QuickAccess

--- a/components/quick-actions.tsx
+++ b/components/quick-actions.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import Link from 'next/link'
+import { LiquidButton } from '@/components/ui/liquid-button'
+
+export interface QuickAction {
+  title: string
+  href?: string
+  onClick?: () => void
+}
+
+interface QuickActionsProps {
+  actions: QuickAction[]
+}
+
+export function QuickActions({ actions }: QuickActionsProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {actions.map((action) => (
+        action.href ? (
+          <Link key={action.title} href={action.href}>
+            <LiquidButton size="sm" variant="primary">
+              {action.title}
+            </LiquidButton>
+          </Link>
+        ) : (
+          <LiquidButton
+            key={action.title}
+            size="sm"
+            variant="primary"
+            onClick={action.onClick}
+          >
+            {action.title}
+          </LiquidButton>
+        )
+      ))}
+    </div>
+  )
+}
+
+export default QuickActions


### PR DESCRIPTION
## Summary
- add QuickAccess component with cards for main features
- add QuickActions component for common actions
- reorganize dashboard layout to include new quick sections

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: invalid Clerk publishableKey)


------
https://chatgpt.com/codex/tasks/task_e_68c7ca9c2e70832f800523f3713627d2