### PR TITLE
Add support for budget item names

### DIFF
--- a/app/api/budget/[id]/route.ts
+++ b/app/api/budget/[id]/route.ts
@@ -98,7 +98,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
           await tx.budgetItem.createMany({
             data: items.map((item: any) => ({
               budgetId: id,
-              name: item.name,
+              name: item.name ?? item.category,
               amount: Number(item.amount),
               spent: Number(item.spent || 0),
               category: item.category,
@@ -111,7 +111,22 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
       // Return updated budget with items
       return await tx.budget.findUnique({
         where: { id },
-        include: { items: true }
+        include: {
+          items: {
+            select: {
+              id: true,
+              budgetId: true,
+              accountId: true,
+              name: true,
+              category: true,
+              amount: true,
+              spent: true,
+              currency: true,
+              createdAt: true,
+              updatedAt: true
+            }
+          }
+        }
       })
     })
 

--- a/app/api/budget/route.ts
+++ b/app/api/budget/route.ts
@@ -12,7 +12,20 @@ export async function GET(request: NextRequest) {
     const budgets = await prisma.budget.findMany({
       where: { userId },
       include: {
-        items: true
+        items: {
+          select: {
+            id: true,
+            budgetId: true,
+            accountId: true,
+            name: true,
+            category: true,
+            amount: true,
+            spent: true,
+            currency: true,
+            createdAt: true,
+            updatedAt: true
+          }
+        }
       },
       orderBy: { createdAt: 'desc' }
     })
@@ -91,6 +104,7 @@ export async function POST(request: NextRequest) {
         isActive: true,
         items: {
           create: items?.map((item: any) => ({
+            name: item.name ?? item.category,
             category: item.category,
             amount: Number(item.amount),
             currency: item.currency || currency || 'BRL'
@@ -98,7 +112,20 @@ export async function POST(request: NextRequest) {
         }
       },
       include: {
-        items: true
+        items: {
+          select: {
+            id: true,
+            budgetId: true,
+            accountId: true,
+            name: true,
+            category: true,
+            amount: true,
+            spent: true,
+            currency: true,
+            createdAt: true,
+            updatedAt: true
+          }
+        }
       }
     })
 

--- a/app/budget/page.tsx
+++ b/app/budget/page.tsx
@@ -184,9 +184,9 @@ export default function BudgetPage() {
                     <div style={{ width: '100%', height: 200 }}>
                       <ResponsiveContainer>
                         <PieChart>
-                          <Pie 
+                          <Pie
                             data={activeBudget.items.map(item => ({
-                              name: item.category,
+                              name: item.name || item.category,
                               value: item.spent ?? 0,
                               budget: item.amount
                             }))}
@@ -219,7 +219,7 @@ export default function BudgetPage() {
                       return (
                         <div key={item.id} className="p-4 glass-effect rounded-xl">
                           <div className="flex items-center justify-between mb-2">
-                            <span className="font-medium text-white">{item.category}</span>
+                            <span className="font-medium text-white">{item.name || item.category}</span>
                             <span className={`text-sm ${isOverBudget ? 'text-red-300' : 'text-slate-300'}`}>
                               {percentage.toFixed(1)}%
                             </span>

--- a/prisma/migrations/20250925000000_add_budget_item_name/migration.sql
+++ b/prisma/migrations/20250925000000_add_budget_item_name/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "BudgetItem" ADD COLUMN "name" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,7 @@ model BudgetItem {
   budget       Budget       @relation(fields: [budgetId], references: [id], onDelete: Cascade)
   accountId    String?
   bankAccount  BankAccount? @relation(fields: [accountId], references: [id])
+  name         String?
   category     String
   amount       Decimal      @db.Decimal(18, 2)
   spent        Decimal      @db.Decimal(18, 2) @default(0)


### PR DESCRIPTION
## Summary
- add an optional name column to budget items in the Prisma schema and migration
- extend the budget API to persist and return item names in GET/POST/PATCH responses
- surface item names on the budget page when available

## Testing
- `npm run build` *(fails: ENCRYPTION_KEY_BASE64 inválido: deve decodificar para 32 bytes)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a4c5e784832f8e455fa93d16eb5b