### PR TITLE
Add edit and delete controls to goals list

### DIFF
--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -225,12 +225,28 @@ export default function GoalsPage() {
                             <p className="text-sm text-slate-400 mt-1">{goal.description}</p>
                           )}
                         </div>
-                        <div className="flex items-center space-x-2">
-                          <span 
+                        <div className="flex items-center gap-2">
+                          <span
                             className="w-3 h-3 rounded-full"
                             style={{ backgroundColor: priorityColor }}
                           />
                           <span className="text-xs text-slate-400 capitalize">{goal.priority}</span>
+                          <button
+                            type="button"
+                            onClick={() => setEditingGoal(goal)}
+                            className="text-blue-400 hover:text-blue-300 text-xs"
+                            title="Editar"
+                          >
+                            ✏️
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => setDeletingGoal(goal.id)}
+                            className="text-red-400 hover:text-red-300 text-xs"
+                            title="Excluir"
+                          >
+                            🗑️
+                          </button>
                         </div>
                       </div>
 


### PR DESCRIPTION
## Summary
- add edit and delete action buttons beside goal priority indicator
- wire buttons to existing editing and deleting handlers for goals
- align goal action styling with budget list controls for consistency

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c8a84daa58832fa245b17720261780