### PR TITLE
Add edit and delete buttons to loan cards

### DIFF
--- a/app/loans/page.tsx
+++ b/app/loans/page.tsx
@@ -212,14 +212,34 @@ export default function LoansPage() {
                   >
                     <LiquidCard variant="hoverable">
                       <div className="flex items-start justify-between mb-3">
-                        <div>
-                          <h3 className="text-lg font-semibold text-white flex items-center gap-2">
-                            {typeIcon} {loan.title}
-                            {loan.isPaid && <span className="text-green-400">✅</span>}
-                            {isOverdue && <span className="text-red-400">⚠️</span>}
-                          </h3>
+                        <div className="space-y-1">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <h3 className="text-lg font-semibold text-white flex items-center gap-2">
+                              {typeIcon} {loan.title}
+                              {loan.isPaid && <span className="text-green-400">✅</span>}
+                              {isOverdue && <span className="text-red-400">⚠️</span>}
+                            </h3>
+                            <div className="flex items-center gap-2">
+                              <LiquidButton
+                                size="sm"
+                                variant="outline"
+                                className="text-xs text-blue-300 border-blue-500/50 hover:bg-blue-500/10"
+                                onClick={() => setEditingLoan(loan)}
+                              >
+                                ✏️ Editar
+                              </LiquidButton>
+                              <LiquidButton
+                                size="sm"
+                                variant="outline"
+                                className="text-xs text-red-300 border-red-500/50 hover:bg-red-500/10"
+                                onClick={() => setDeletingLoan(loan.id)}
+                              >
+                                🗑️ Excluir
+                              </LiquidButton>
+                            </div>
+                          </div>
                           {loan.description && (
-                            <p className="text-sm text-slate-400 mt-1">{loan.description}</p>
+                            <p className="text-sm text-slate-400">{loan.description}</p>
                           )}
                         </div>
                         <div className="text-right">


### PR DESCRIPTION
## Summary
- add edit and delete LiquidButton controls next to each loan title on the loans page to trigger edit and delete actions

## Testing
- npm run lint *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_68c8a96bb150832fbe694c4ee558e3c7