### PR TITLE
Add scrollable max height to form modals

### DIFF
--- a/components/forms/goal-form.tsx
+++ b/components/forms/goal-form.tsx
@@ -59,7 +59,7 @@ export function GoalForm({ goal, onSubmit, onCancel, loading }: GoalFormProps) {
       <motion.div
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
-        className="w-full max-w-lg"
+        className="w-full max-w-lg max-h-[90vh] overflow-y-auto"
       >
         <LiquidCard>
           <form onSubmit={handleSubmit} className="space-y-6">

--- a/components/forms/loan-form.tsx
+++ b/components/forms/loan-form.tsx
@@ -68,7 +68,7 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
       <motion.div
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
-        className="w-full max-w-lg"
+        className="w-full max-w-lg max-h-[90vh] overflow-y-auto"
       >
         <LiquidCard>
           <form onSubmit={handleSubmit} className="space-y-6">

--- a/components/forms/subscription-form.tsx
+++ b/components/forms/subscription-form.tsx
@@ -59,7 +59,7 @@ export function SubscriptionForm({ subscription, onSubmit, onCancel, loading }: 
       <motion.div
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
-        className="w-full max-w-lg"
+        className="w-full max-w-lg max-h-[90vh] overflow-y-auto"
       >
         <LiquidCard>
           <form onSubmit={handleSubmit} className="space-y-6">


### PR DESCRIPTION
## Summary
- add max height and overflow auto constraints to the loan, goal and subscription form modals to keep them within the viewport

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68c8b43ed6dc832fb7b161da0b41cafe