### PR TITLE
Add transaction calendar overview to dashboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -38,6 +38,10 @@ import {
   EmptyUpcomingPayments
 } from '@/components/ui/empty-state'
 import { createHandleConnect } from '@/lib/pluggy-connect'
+import {
+  TransactionCalendar,
+  type TransactionCalendarDay,
+} from '@/components/transactions/transaction-calendar'
 
 interface Transaction {
   id: string
@@ -319,6 +323,30 @@ export default function Dashboard() {
     name,
     value,
   }))
+
+  const calendarData = Object.values(
+    transactions.reduce<Record<string, TransactionCalendarDay>>((acc, t) => {
+      const normalizedDate = formatDateForInput(t.date)
+
+      const current = acc[normalizedDate] ?? {
+        date: normalizedDate,
+        income: 0,
+        expense: 0,
+      }
+
+      acc[normalizedDate] = {
+        ...current,
+        income: current.income + (t.amount >= 0 ? t.amount : 0),
+        expense: current.expense + (t.amount < 0 ? Math.abs(t.amount) : 0),
+      }
+
+      return acc
+    }, {})
+  ).sort(
+    (a, b) =>
+      new Date(`${a.date}T00:00:00`).getTime() -
+      new Date(`${b.date}T00:00:00`).getTime()
+  )
 
   const quickAccessItems: QuickAccessItem[] = [
     {
@@ -664,6 +692,34 @@ export default function Dashboard() {
                 </PieChart>
               </ResponsiveContainer>
             </div>
+          )}
+        </LiquidCard>
+      </motion.div>
+
+      <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+        <LiquidCard>
+          <h2 className="text-xl font-semibold">Calendário Financeiro</h2>
+          <p className="text-sm text-slate-400 mt-1 mb-4">
+            Acompanhe o total diário de receitas e despesas.
+          </p>
+          {loading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="rounded-2xl border border-card-border/60 bg-card-glass/40 p-4"
+                >
+                  <div className="mb-3 h-4 w-24 rounded bg-card-glass/60 animate-pulse" />
+                  <div className="mb-4 flex gap-3">
+                    <div className="h-16 flex-1 rounded-xl bg-card-glass/60 animate-pulse" />
+                    <div className="h-16 flex-1 rounded-xl bg-card-glass/60 animate-pulse" />
+                  </div>
+                  <div className="h-2 w-full rounded-full bg-card-glass/60 animate-pulse" />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <TransactionCalendar days={calendarData} />
           )}
         </LiquidCard>
       </motion.div>

--- a/components/transactions/transaction-calendar.tsx
+++ b/components/transactions/transaction-calendar.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { formatCurrency, formatDate } from '@/lib/format-utils'
+import { cn } from '@/lib/utils'
+
+export interface TransactionCalendarDay {
+  date: string
+  income: number
+  expense: number
+}
+
+interface TransactionCalendarProps {
+  days: TransactionCalendarDay[]
+}
+
+const weekdayFormatter = new Intl.DateTimeFormat('pt-BR', {
+  weekday: 'short',
+})
+
+const monthFormatter = new Intl.DateTimeFormat('pt-BR', {
+  month: 'short',
+})
+
+export function TransactionCalendar({ days }: TransactionCalendarProps) {
+  if (!days || days.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-10 text-center text-slate-400">
+        <span className="text-4xl mb-2">🗓️</span>
+        <p className="text-base font-medium text-slate-300">
+          Nenhuma movimentação encontrada
+        </p>
+        <p className="text-sm text-slate-400/80">
+          As receitas e despesas consolidadas aparecerão aqui assim que você registrar transações.
+        </p>
+      </div>
+    )
+  }
+
+  const sortedDays = [...days].sort(
+    (a, b) =>
+      new Date(`${a.date}T00:00:00`).getTime() -
+      new Date(`${b.date}T00:00:00`).getTime()
+  )
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide text-slate-400">
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-emerald-400" />
+          Receitas
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-rose-400" />
+          Despesas
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="h-2 w-2 rounded-full bg-blue-400" />
+          Saldo do dia
+        </div>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+        {sortedDays.map((day) => {
+          const displayDateString = `${day.date}T00:00:00`
+          const dayDate = new Date(displayDateString)
+          const weekDay = weekdayFormatter.format(dayDate).replace('.', '')
+          const monthLabel = monthFormatter.format(dayDate).replace('.', '')
+          const dayNumber = dayDate.getDate().toString().padStart(2, '0')
+          const balance = day.income - day.expense
+          const total = day.income + day.expense
+          const incomePercent = total > 0 ? (day.income / total) * 100 : 0
+          const expensePercent = total > 0 ? (day.expense / total) * 100 : 0
+
+          return (
+            <div
+              key={day.date}
+              className={cn(
+                'rounded-2xl border border-white/5 bg-card-glass/40 p-4 transition-all duration-200 hover:-translate-y-1 hover:bg-card-glass/60',
+                balance >= 0
+                  ? 'shadow-[0_0_25px_rgba(16,185,129,0.12)] hover:border-emerald-400/40'
+                  : 'shadow-[0_0_25px_rgba(248,113,113,0.12)] hover:border-rose-400/40'
+              )}
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <div className="text-xs uppercase tracking-wide text-slate-400">
+                    {weekDay}
+                  </div>
+                  <div className="text-2xl font-semibold text-white">
+                    {dayNumber}
+                    <span className="ml-1 text-sm font-normal text-slate-400">
+                      {monthLabel}
+                    </span>
+                  </div>
+                  <div className="text-xs text-slate-500">{formatDate(displayDateString)}</div>
+                </div>
+                <div
+                  className={cn(
+                    'rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide',
+                    balance >= 0
+                      ? 'border-emerald-400/30 bg-emerald-500/15 text-emerald-200'
+                      : 'border-rose-400/30 bg-rose-500/15 text-rose-200'
+                  )}
+                >
+                  {balance >= 0 ? 'Saldo positivo' : 'Saldo negativo'}
+                </div>
+              </div>
+
+              <div className="mt-4 grid grid-cols-2 gap-3 text-sm">
+                <div className="rounded-xl border border-emerald-400/20 bg-emerald-500/10 p-3">
+                  <div className="text-xs uppercase tracking-wide text-emerald-200/80">
+                    Receitas
+                  </div>
+                  <div className="text-lg font-semibold text-emerald-100">
+                    {formatCurrency(day.income)}
+                  </div>
+                </div>
+                <div className="rounded-xl border border-rose-400/20 bg-rose-500/10 p-3">
+                  <div className="text-xs uppercase tracking-wide text-rose-200/80">
+                    Despesas
+                  </div>
+                  <div className="text-lg font-semibold text-rose-100">
+                    {formatCurrency(day.expense)}
+                  </div>
+                </div>
+              </div>
+
+              <div className="mt-4">
+                <div className="flex items-center justify-between text-xs text-slate-400">
+                  <span>Saldo</span>
+                  <span
+                    className={cn(
+                      'font-semibold',
+                      balance >= 0 ? 'text-emerald-200' : 'text-rose-200'
+                    )}
+                  >
+                    {formatCurrency(balance)}
+                  </span>
+                </div>
+                <div className="mt-2 flex h-2 overflow-hidden rounded-full bg-white/5">
+                  <div
+                    className="h-full bg-emerald-400/80"
+                    style={{ width: `${incomePercent}%` }}
+                  />
+                  <div
+                    className="h-full bg-rose-400/80"
+                    style={{ width: `${expensePercent}%` }}
+                  />
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a TransactionCalendar component to display daily income and expense totals
- aggregate dashboard transactions into normalized calendar data
- surface the calendar inside the dashboard with a loading placeholder

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68c9ad26a52c832fb1dd91bd9fd5871d