### PR TITLE
Normalize dashboard calendar dates with Brazil timezone

### DIFF
--- a/components/forms/transaction-form.tsx
+++ b/components/forms/transaction-form.tsx
@@ -5,6 +5,7 @@ import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
 import { LiquidInput } from '@/components/ui/liquid-input'
+import { formatDateToISODate } from '@/lib/format-utils'
 
 export interface TransactionFormData {
   id?: string
@@ -22,23 +23,7 @@ interface TransactionFormProps {
   submitting?: boolean
 }
 
-const getTodayInputValue = () => new Date().toISOString().split('T')[0]
-
-const ensureDateValue = (value?: string | null) => {
-  if (!value) return getTodayInputValue()
-
-  const parsed = new Date(value)
-  if (!Number.isNaN(parsed.getTime())) {
-    return parsed.toISOString().split('T')[0]
-  }
-
-  const match = value.match(/^\d{4}-\d{2}-\d{2}/)
-  if (match) {
-    return match[0]
-  }
-
-  return getTodayInputValue()
-}
+const ensureDateValue = (value?: string | null) => formatDateToISODate(value)
 
 export function TransactionForm({
   transaction,


### PR DESCRIPTION
## Summary
- add a reusable helper to normalize dates to YYYY-MM-DD using the America/Sao_Paulo timezone
- reuse the helper when preparing dashboard transactions and form defaults to keep manual tests around midnight consistent
- adjust the transaction calendar to parse and format days in the Brazilian timezone so weekday/month labels match expectations

## Testing
- npm run build *(fails: ENCRYPTION_KEY_BASE64 inválido: deve decodificar para 32 bytes)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b71d3660832fbfb106bce0ca3f98