### PR TITLE
Adjust quick actions to open creation modals via query

### DIFF
--- a/app/budget/page.tsx
+++ b/app/budget/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
@@ -15,10 +16,30 @@ export default function BudgetPage() {
   const [showCreateForm, setShowCreateForm] = useState(false)
   const [editingBudget, setEditingBudget] = useState<Budget | null>(null)
   const [deletingBudget, setDeletingBudget] = useState<string | null>(null)
+  const [hasOpenedFromQuery, setHasOpenedFromQuery] = useState(false)
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
 
   useEffect(() => {
     loadBudgets()
   }, [])
+
+  useEffect(() => {
+    if (hasOpenedFromQuery) {
+      return
+    }
+
+    if (searchParams?.get('create') === '1') {
+      setShowCreateForm(true)
+      setHasOpenedFromQuery(true)
+
+      const params = new URLSearchParams(searchParams.toString())
+      params.delete('create')
+      const queryString = params.toString()
+      router.replace(`${pathname}${queryString ? `?${queryString}` : ''}`, { scroll: false })
+    }
+  }, [hasOpenedFromQuery, pathname, router, searchParams])
 
   async function loadBudgets() {
     try {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -376,8 +376,8 @@ export default function Dashboard() {
   const quickActions: QuickAction[] = [
     { title: 'Nova Transação', onClick: handleOpenNewTransactionModal },
     { title: 'Conectar Conta', onClick: handleConnect },
-    { title: 'Adicionar Meta', href: '/goals/new' },
-    { title: 'Novo Orçamento', href: '/budget/new' },
+    { title: 'Adicionar Meta', onClick: () => router.push('/goals?create=1') },
+    { title: 'Novo Orçamento', onClick: () => router.push('/budget?create=1') },
   ]
 
   // Calcular KPIs principais

--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
@@ -26,10 +27,30 @@ export default function GoalsPage() {
   const [showCreateForm, setShowCreateForm] = useState(false)
   const [editingGoal, setEditingGoal] = useState<Goal | null>(null)
   const [deletingGoal, setDeletingGoal] = useState<string | null>(null)
+  const [hasOpenedFromQuery, setHasOpenedFromQuery] = useState(false)
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
 
   useEffect(() => {
     loadGoals()
   }, [])
+
+  useEffect(() => {
+    if (hasOpenedFromQuery) {
+      return
+    }
+
+    if (searchParams?.get('create') === '1') {
+      setShowCreateForm(true)
+      setHasOpenedFromQuery(true)
+
+      const params = new URLSearchParams(searchParams.toString())
+      params.delete('create')
+      const queryString = params.toString()
+      router.replace(`${pathname}${queryString ? `?${queryString}` : ''}`, { scroll: false })
+    }
+  }, [hasOpenedFromQuery, pathname, router, searchParams])
 
   async function loadGoals() {
     try {


### PR DESCRIPTION
## Summary
- update dashboard quick actions to route to goals and budget pages with query flags
- auto-open goal and budget creation modals when arriving with create=1 and clear the flag afterward

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ca285dce98832f81771ff91ba1f4f9