### PR TITLE
refactor: reuse confirm delete modal across pages

### DIFF
--- a/app/budget/page.tsx
+++ b/app/budget/page.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
+import { ConfirmDeleteModal } from '@/components/ui/confirm-delete-modal'
 import { BudgetForm } from '@/components/forms/budget-form'
 import { Budget } from '@/types/budget'
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, BarChart, Bar, XAxis, YAxis } from 'recharts'
@@ -364,31 +365,12 @@ export default function BudgetPage() {
         />
       )}
 
-      {/* Delete Confirmation Modal */}
-      {deletingBudget && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <LiquidCard className="max-w-md w-full m-4">
-            <h3 className="text-xl font-semibold mb-4 text-white">Confirmar Exclusão</h3>
-            <p className="text-slate-400 mb-6">Tem certeza que deseja excluir este orçamento? Esta ação não pode ser desfeita.</p>
-            <div className="flex gap-3">
-              <LiquidButton 
-                variant="secondary" 
-                onClick={() => setDeletingBudget(null)}
-                className="flex-1"
-              >
-                Cancelar
-              </LiquidButton>
-              <LiquidButton 
-                variant="primary" 
-                onClick={() => handleDeleteBudget(deletingBudget)}
-                className="flex-1 bg-red-500 hover:bg-red-600"
-              >
-                Excluir
-              </LiquidButton>
-            </div>
-          </LiquidCard>
-        </div>
-      )}
+      <ConfirmDeleteModal
+        isOpen={Boolean(deletingBudget)}
+        message="Tem certeza que deseja excluir este orçamento? Esta ação não pode ser desfeita."
+        onCancel={() => setDeletingBudget(null)}
+        onConfirm={() => handleDeleteBudget(deletingBudget!)}
+      />
     </div>
   )
 }

--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
+import { ConfirmDeleteModal } from '@/components/ui/confirm-delete-modal'
 import { GoalForm } from '@/components/forms/goal-form'
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, BarChart, Bar, XAxis, YAxis } from 'recharts'
 
@@ -377,31 +378,12 @@ export default function GoalsPage() {
         />
       )}
 
-      {/* Delete Confirmation Modal */}
-      {deletingGoal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <LiquidCard className="max-w-md w-full m-4">
-            <h3 className="text-xl font-semibold mb-4 text-white">Confirmar Exclusão</h3>
-            <p className="text-slate-400 mb-6">Tem certeza que deseja excluir esta meta? Esta ação não pode ser desfeita.</p>
-            <div className="flex gap-3">
-              <LiquidButton 
-                variant="secondary" 
-                onClick={() => setDeletingGoal(null)}
-                className="flex-1"
-              >
-                Cancelar
-              </LiquidButton>
-              <LiquidButton 
-                variant="primary" 
-                onClick={() => handleDeleteGoal(deletingGoal)}
-                className="flex-1 bg-red-500 hover:bg-red-600"
-              >
-                Excluir
-              </LiquidButton>
-            </div>
-          </LiquidCard>
-        </div>
-      )}
+      <ConfirmDeleteModal
+        isOpen={Boolean(deletingGoal)}
+        message="Tem certeza que deseja excluir esta meta? Esta ação não pode ser desfeita."
+        onCancel={() => setDeletingGoal(null)}
+        onConfirm={() => handleDeleteGoal(deletingGoal!)}
+      />
     </div>
   )
 }

--- a/app/loans/page.tsx
+++ b/app/loans/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
+import { ConfirmDeleteModal } from '@/components/ui/confirm-delete-modal'
 import { LoanForm } from '@/components/forms/loan-form'
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, PieChart, Pie, Cell } from 'recharts'
 
@@ -407,31 +408,12 @@ export default function LoansPage() {
         />
       )}
 
-      {/* Delete Confirmation Modal */}
-      {deletingLoan && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <LiquidCard className="max-w-md w-full m-4">
-            <h3 className="text-xl font-semibold mb-4 text-white">Confirmar Exclusão</h3>
-            <p className="text-slate-400 mb-6">Tem certeza que deseja excluir este empréstimo? Esta ação não pode ser desfeita.</p>
-            <div className="flex gap-3">
-              <LiquidButton 
-                variant="secondary" 
-                onClick={() => setDeletingLoan(null)}
-                className="flex-1"
-              >
-                Cancelar
-              </LiquidButton>
-              <LiquidButton 
-                variant="primary" 
-                onClick={() => handleDeleteLoan(deletingLoan)}
-                className="flex-1 bg-red-500 hover:bg-red-600"
-              >
-                Excluir
-              </LiquidButton>
-            </div>
-          </LiquidCard>
-        </div>
-      )}
+      <ConfirmDeleteModal
+        isOpen={Boolean(deletingLoan)}
+        message="Tem certeza que deseja excluir este empréstimo? Esta ação não pode ser desfeita."
+        onCancel={() => setDeletingLoan(null)}
+        onConfirm={() => handleDeleteLoan(deletingLoan!)}
+      />
     </div>
   )
 }

--- a/app/subscriptions/page.tsx
+++ b/app/subscriptions/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
+import { ConfirmDeleteModal } from '@/components/ui/confirm-delete-modal'
 import { SubscriptionForm } from '@/components/forms/subscription-form'
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, PieChart, Pie, Cell } from 'recharts'
 
@@ -410,31 +411,12 @@ export default function SubscriptionsPage() {
         />
       )}
 
-      {/* Delete Confirmation Modal */}
-      {deletingSubscription && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <LiquidCard className="max-w-md w-full m-4">
-            <h3 className="text-xl font-semibold mb-4 text-white">Confirmar Exclusão</h3>
-            <p className="text-slate-400 mb-6">Tem certeza que deseja excluir esta assinatura? Esta ação não pode ser desfeita.</p>
-            <div className="flex gap-3">
-              <LiquidButton 
-                variant="secondary" 
-                onClick={() => setDeletingSubscription(null)}
-                className="flex-1"
-              >
-                Cancelar
-              </LiquidButton>
-              <LiquidButton 
-                variant="primary" 
-                onClick={() => handleDeleteSubscription(deletingSubscription)}
-                className="flex-1 bg-red-500 hover:bg-red-600"
-              >
-                Excluir
-              </LiquidButton>
-            </div>
-          </LiquidCard>
-        </div>
-      )}
+      <ConfirmDeleteModal
+        isOpen={Boolean(deletingSubscription)}
+        message="Tem certeza que deseja excluir esta assinatura? Esta ação não pode ser desfeita."
+        onCancel={() => setDeletingSubscription(null)}
+        onConfirm={() => handleDeleteSubscription(deletingSubscription!)}
+      />
     </div>
   )
 }

--- a/components/ui/confirm-delete-modal.tsx
+++ b/components/ui/confirm-delete-modal.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { useId } from 'react'
+import { LiquidCard } from '@/components/ui/liquid-card'
+import { LiquidButton } from '@/components/ui/liquid-button'
+import { cn } from '@/lib/utils'
+
+interface ConfirmDeleteModalProps {
+  isOpen: boolean
+  title?: string
+  message: string
+  cancelLabel?: string
+  confirmLabel?: string
+  onCancel: () => void
+  onConfirm: () => void
+  cancelButtonClassName?: string
+  confirmButtonClassName?: string
+}
+
+export function ConfirmDeleteModal({
+  isOpen,
+  title = 'Confirmar Exclusão',
+  message,
+  cancelLabel = 'Cancelar',
+  confirmLabel = 'Excluir',
+  onCancel,
+  onConfirm,
+  cancelButtonClassName,
+  confirmButtonClassName
+}: ConfirmDeleteModalProps) {
+  const titleId = useId()
+  const descriptionId = useId()
+
+  if (!isOpen) {
+    return null
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <LiquidCard
+        className="max-w-md w-full m-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+      >
+        <h3 id={titleId} className="text-xl font-semibold mb-4 text-white">
+          {title}
+        </h3>
+        <p id={descriptionId} className="text-slate-400 mb-6">
+          {message}
+        </p>
+        <div className="flex gap-3">
+          <LiquidButton
+            variant="secondary"
+            onClick={onCancel}
+            className={cn('flex-1', cancelButtonClassName)}
+          >
+            {cancelLabel}
+          </LiquidButton>
+          <LiquidButton
+            variant="primary"
+            onClick={onConfirm}
+            className={cn('flex-1 bg-red-500 hover:bg-red-600', confirmButtonClassName)}
+          >
+            {confirmLabel}
+          </LiquidButton>
+        </div>
+      </LiquidCard>
+    </div>
+  )
+}
+
+export default ConfirmDeleteModal


### PR DESCRIPTION
## Summary
- add a reusable confirm delete modal component that preserves the liquid UI styling and accessibility attributes
- replace the inline delete confirmation dialogs in the budget, goals, subscriptions, and loans pages with the shared component

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca2fe1f304832fbd4c6dcd00078be2