### PR TITLE
feat: add account management placeholder routes

### DIFF
--- a/__tests__/user-dropdown-routes.test.ts
+++ b/__tests__/user-dropdown-routes.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+const routes = [
+  { modulePath: '@/app/profile/page', title: 'Meu Perfil | Financeito' },
+  { modulePath: '@/app/settings/page', title: 'Configurações | Financeito' },
+  { modulePath: '@/app/security/page', title: 'Segurança | Financeito' },
+  { modulePath: '@/app/billing/page', title: 'Planos e Cobrança | Financeito' },
+  { modulePath: '@/app/notifications/page', title: 'Notificações | Financeito' },
+  { modulePath: '@/app/help/page', title: 'Ajuda e Suporte | Financeito' },
+] as const
+
+describe('user dropdown routes', () => {
+  it.each(routes)('exports a valid page component for %s', async ({ modulePath, title }) => {
+    const pageModule = await import(modulePath)
+
+    expect(pageModule).toBeDefined()
+    expect(pageModule.default).toBeTypeOf('function')
+    expect(pageModule.metadata?.title).toBe(title)
+  })
+})

--- a/app/billing/page.tsx
+++ b/app/billing/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+export const metadata: Metadata = {
+  title: 'Planos e Cobrança | Financeito',
+}
+
+export default function BillingPage() {
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Planos &amp; Cobrança</CardTitle>
+          <CardDescription>Gerencie sua assinatura do Financeito.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Consulte histórico de pagamentos, método de cobrança e atualize o plano quando disponível.
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/subscriptions">Ver minhas assinaturas</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,0 +1,34 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+export const metadata: Metadata = {
+  title: 'Ajuda e Suporte | Financeito',
+}
+
+export default function HelpPage() {
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Ajuda &amp; Suporte</CardTitle>
+          <CardDescription>Encontre recursos para tirar dúvidas sobre o Financeito.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Consulte nossa base de conhecimento, envie um e-mail para suporte ou acesse a comunidade.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <Button asChild variant="outline">
+              <Link href="mailto:suporte@financeito.app">Contactar suporte</Link>
+            </Button>
+            <Button asChild variant="ghost">
+              <Link href="/dashboard">Voltar ao dashboard</Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+export const metadata: Metadata = {
+  title: 'Notificações | Financeito',
+}
+
+export default function NotificationsPage() {
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Notificações</CardTitle>
+          <CardDescription>Centralize alertas importantes da sua vida financeira.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Em breve você poderá configurar notificações por e-mail e push para eventos relevantes.
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/dashboard">Voltar ao dashboard</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+export const metadata: Metadata = {
+  title: 'Meu Perfil | Financeito',
+}
+
+export default function ProfilePage() {
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Meu Perfil</CardTitle>
+          <CardDescription>Gerencie suas informações pessoais no Financeito.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Aqui você poderá revisar e atualizar os dados vinculados à sua conta.
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/dashboard">Voltar ao dashboard</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/security/page.tsx
+++ b/app/security/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+export const metadata: Metadata = {
+  title: 'Segurança | Financeito',
+}
+
+export default function SecurityPage() {
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Segurança da Conta</CardTitle>
+          <CardDescription>Gerencie fatores de autenticação e sessões ativas.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Configure autenticação em dois fatores, redefina sua senha e monitore dispositivos confiáveis por aqui.
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/dashboard">Voltar ao dashboard</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+export const metadata: Metadata = {
+  title: 'Configurações | Financeito',
+}
+
+export default function SettingsPage() {
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Configurações</CardTitle>
+          <CardDescription>Personalize como o Financeito funciona para você.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Em breve você poderá definir preferências gerais, idioma e integrações.
+          </p>
+          <Button asChild variant="outline">
+            <Link href="/dashboard">Voltar ao dashboard</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add placeholder screens for profile, settings, security, billing, notifications and help routes referenced by the user dropdown
- add regression test ensuring each dropdown route exports a page component and metadata title

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca3d95f15c832f8d1088231edec286