### PR TITLE
Add integrations entry to navigation and quick access

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -370,6 +370,11 @@ export default function Dashboard() {
       description: 'Controle suas assinaturas',
       href: '/subscriptions',
     },
+    {
+      title: 'Integrações',
+      description: 'Gerencie conexões com bancos e serviços',
+      href: '/integrations',
+    },
     { title: 'Empréstimos', description: 'Gerencie seus empréstimos', href: '/loans' },
   ]
 

--- a/components/fluid-sidebar.tsx
+++ b/components/fluid-sidebar.tsx
@@ -1,14 +1,15 @@
 "use client"
 
 import { MenuItem, MenuContainer } from "@/components/ui/fluid-menu"
-import { 
-  Menu as MenuIcon, 
-  X, 
-  Home, 
-  PiggyBank, 
-  Target, 
-  CreditCard, 
-  TrendingUp 
+import {
+  Menu as MenuIcon,
+  X,
+  Home,
+  PiggyBank,
+  Target,
+  CreditCard,
+  TrendingUp,
+  Plug,
 } from "lucide-react"
 
 export default function FluidSidebar() {
@@ -17,6 +18,7 @@ export default function FluidSidebar() {
     { href: '/budget', label: 'Orçamento', icon: <PiggyBank size={20} strokeWidth={1.5} /> },
     { href: '/goals', label: 'Metas', icon: <Target size={20} strokeWidth={1.5} /> },
     { href: '/subscriptions', label: 'Assinaturas', icon: <CreditCard size={20} strokeWidth={1.5} /> },
+    { href: '/integrations', label: 'Integrações', icon: <Plug size={20} strokeWidth={1.5} /> },
     { href: '/loans', label: 'Empréstimos', icon: <TrendingUp size={20} strokeWidth={1.5} /> },
   ]
 


### PR DESCRIPTION
## Summary
- add the Integrations shortcut to the fluid sidebar navigation with the Plug icon
- expose a dashboard quick access entry pointing users to the integrations page

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68cb41e004d0832f988cd459a7234e5d