### PR TITLE
Handle Pluggy integration configuration errors gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ cp .env.example .env
 nano .env
 ```
 No arquivo `.env`, defina `ENCRYPTION_KEY_BASE64` com uma chave de 32 bytes codificada em Base64 para criptografia dos dados sensíveis.
-A aplicação não inicia sem uma `ENCRYPTION_KEY_BASE64` válida (deve decodificar para 32 bytes).
+Sem uma chave válida, as rotas de sincronização responderão com `503` exibindo o erro `ENCRYPTION_KEY_BASE64 ausente ou inválido. Configure uma chave Base64 de 32 bytes (256 bits) para habilitar a criptografia.`
 
 ### Variáveis Pluggy
-- `PLUGGY_CLIENT_ID` e `PLUGGY_CLIENT_SECRET`: credenciais do painel Pluggy.
+- `PLUGGY_CLIENT_ID` e `PLUGGY_CLIENT_SECRET`: credenciais do painel Pluggy. Sem elas, as rotas retornarão `503` com o erro `PLUGGY_CLIENT_ID e/ou PLUGGY_CLIENT_SECRET não foram configurados. Defina as variáveis de ambiente antes de usar a integração.`
 - `PLUGGY_BASE_URL` e `PLUGGY_ENV`: ajuste conforme o ambiente desejado.
 
 ### Variáveis Google (backups)

--- a/app/api/pluggy/link-token/route.ts
+++ b/app/api/pluggy/link-token/route.ts
@@ -1,10 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createConnectToken } from '@/lib/pluggy'
+import { ConfigurationError, createConnectToken } from '@/lib/pluggy'
 import { auth } from '@clerk/nextjs/server'
 
 export async function POST(req: NextRequest) {
   const { userId } = auth()
   if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const data = await createConnectToken({})
-  return NextResponse.json(data)
+  try {
+    const data = await createConnectToken({})
+    return NextResponse.json(data)
+  } catch (error) {
+    if (error instanceof ConfigurationError) {
+      console.error('Falha de configuração do Pluggy (link-token):', error)
+      return NextResponse.json({ error: error.message }, { status: 503 })
+    }
+    console.error('Erro ao criar connect token do Pluggy:', error)
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+  }
 }

--- a/app/api/pluggy/sync/route.ts
+++ b/app/api/pluggy/sync/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { listAccounts, listTransactions } from '@/lib/pluggy'
-import { encryptJSON, decryptJSON } from '@/lib/crypto'
+import { ConfigurationError, listAccounts, listTransactions } from '@/lib/pluggy'
+import { EncryptionConfigError, encryptJSON, decryptJSON } from '@/lib/crypto'
 import { auth } from '@clerk/nextjs/server'
 import { prisma } from '@/lib/db'
 import { Prisma } from '@prisma/client'
@@ -12,94 +12,112 @@ export async function POST(req: NextRequest) {
   const { itemId } = await req.json()
   if (!itemId) return NextResponse.json({ error: 'itemId required' }, { status: 400 })
 
-  await ensureUser(userId)
+  try {
+    await ensureUser(userId)
 
-  const accResp = await listAccounts({ itemId })
-  const accounts = accResp.results || accResp
-  for (const acc of accounts) {
-    await prisma.bankAccount.upsert({
-      where: { id: acc.id },
-      update: {
-        userId,
-        provider: 'pluggy',
-        providerItem: itemId,
-        name: acc.name,
-        currency: acc.currencyCode || acc.currency || 'BRL',
-        balance: new Prisma.Decimal(acc.balance ?? 0),
-        mask: acc.number ? String(acc.number).slice(-4) : null,
-        dataEnc: encryptJSON(acc),
-      },
-      create: {
-        id: acc.id,
-        userId,
-        provider: 'pluggy',
-        providerItem: itemId,
-        name: acc.name,
-        currency: acc.currencyCode || acc.currency || 'BRL',
-        balance: new Prisma.Decimal(acc.balance ?? 0),
-        mask: acc.number ? String(acc.number).slice(-4) : null,
-        dataEnc: encryptJSON(acc),
-      },
-    })
+    const accResp = await listAccounts({ itemId })
+    const accounts = accResp.results || accResp
+    for (const acc of accounts) {
+      await prisma.bankAccount.upsert({
+        where: { id: acc.id },
+        update: {
+          userId,
+          provider: 'pluggy',
+          providerItem: itemId,
+          name: acc.name,
+          currency: acc.currencyCode || acc.currency || 'BRL',
+          balance: new Prisma.Decimal(acc.balance ?? 0),
+          mask: acc.number ? String(acc.number).slice(-4) : null,
+          dataEnc: encryptJSON(acc),
+        },
+        create: {
+          id: acc.id,
+          userId,
+          provider: 'pluggy',
+          providerItem: itemId,
+          name: acc.name,
+          currency: acc.currencyCode || acc.currency || 'BRL',
+          balance: new Prisma.Decimal(acc.balance ?? 0),
+          mask: acc.number ? String(acc.number).slice(-4) : null,
+          dataEnc: encryptJSON(acc),
+        },
+      })
+    }
+
+    const firstResp = await listTransactions({ itemId, pageSize: 500 })
+    const allTxs = [...(firstResp.results || firstResp)]
+    let nextPage = firstResp.nextPage || firstResp.results?.nextPage
+    while (nextPage) {
+      const resp = await listTransactions({ itemId, pageSize: 500, page: nextPage })
+      allTxs.push(...(resp.results || resp))
+      nextPage = resp.nextPage || resp.results?.nextPage
+    }
+
+    for (const tx of allTxs) {
+      await prisma.transaction.upsert({
+        where: { id: tx.id },
+        update: {
+          accountId: tx.accountId,
+          userId,
+          description: tx.description,
+          category: tx.category || null,
+          currency: tx.currencyCode || tx.currency || 'BRL',
+          amount: new Prisma.Decimal(tx.amount || 0),
+          date: new Date(tx.date),
+          rawEnc: encryptJSON(tx),
+        },
+        create: {
+          id: tx.id,
+          accountId: tx.accountId,
+          userId,
+          description: tx.description,
+          category: tx.category || null,
+          currency: tx.currencyCode || tx.currency || 'BRL',
+          amount: new Prisma.Decimal(tx.amount || 0),
+          date: new Date(tx.date),
+          rawEnc: encryptJSON(tx),
+        },
+      })
+    }
+
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    if (error instanceof ConfigurationError || error instanceof EncryptionConfigError) {
+      console.error('Falha de configuração ao sincronizar Pluggy:', error)
+      return NextResponse.json({ error: error.message }, { status: 503 })
+    }
+    console.error('Erro inesperado ao sincronizar Pluggy:', error)
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
   }
-
-  const firstResp = await listTransactions({ itemId, pageSize: 500 })
-  const allTxs = [...(firstResp.results || firstResp)]
-  let nextPage = firstResp.nextPage || firstResp.results?.nextPage
-  while (nextPage) {
-    const resp = await listTransactions({ itemId, pageSize: 500, page: nextPage })
-    allTxs.push(...(resp.results || resp))
-    nextPage = resp.nextPage || resp.results?.nextPage
-  }
-
-  for (const tx of allTxs) {
-    await prisma.transaction.upsert({
-      where: { id: tx.id },
-      update: {
-        accountId: tx.accountId,
-        userId,
-        description: tx.description,
-        category: tx.category || null,
-        currency: tx.currencyCode || tx.currency || 'BRL',
-        amount: new Prisma.Decimal(tx.amount || 0),
-        date: new Date(tx.date),
-        rawEnc: encryptJSON(tx),
-      },
-      create: {
-        id: tx.id,
-        accountId: tx.accountId,
-        userId,
-        description: tx.description,
-        category: tx.category || null,
-        currency: tx.currencyCode || tx.currency || 'BRL',
-        amount: new Prisma.Decimal(tx.amount || 0),
-        date: new Date(tx.date),
-        rawEnc: encryptJSON(tx),
-      },
-    })
-  }
-
-  return NextResponse.json({ ok: true })
 }
 
 export async function GET(req: NextRequest) {
   const { userId: uid } = auth()
   if (!uid) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  const accounts = await prisma.bankAccount.findMany({ where: { userId: uid } })
-  const transactions = await prisma.transaction.findMany({
-    where: { userId: uid },
-    orderBy: { date: 'desc' },
-    take: 50,
-  })
-  const accs = accounts.map((a) => ({
-    ...a,
-    data: a.dataEnc ? decryptJSON(a.dataEnc) : null,
-  }))
-  const txs = transactions.map((t) => ({
-    ...t,
-    raw: t.rawEnc ? decryptJSON(t.rawEnc) : null,
-  }))
-  return NextResponse.json({ accounts: accs, transactions: txs })
+  try {
+    const accounts = await prisma.bankAccount.findMany({ where: { userId: uid } })
+    const transactions = await prisma.transaction.findMany({
+      where: { userId: uid },
+      orderBy: { date: 'desc' },
+      take: 50,
+    })
+    const accs = accounts.map((a) => ({
+      ...a,
+      data: a.dataEnc ? decryptJSON(a.dataEnc) : null,
+    }))
+    const txs = transactions.map((t) => ({
+      ...t,
+      raw: t.rawEnc ? decryptJSON(t.rawEnc) : null,
+    }))
+    return NextResponse.json({ accounts: accs, transactions: txs })
+  } catch (error) {
+    if (error instanceof EncryptionConfigError) {
+      console.error('Falha de configuração ao ler dados Pluggy:', error)
+      return NextResponse.json({ error: error.message }, { status: 503 })
+    }
+    console.error('Erro inesperado ao listar dados Pluggy:', error)
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+  }
 }
 
 export async function DELETE(req: NextRequest) {

--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -45,7 +45,16 @@ export default function IntegrationsPage() {
       }
 
       if (!response.ok) {
-        throw new Error('Failed to load accounts')
+        let message = 'Não foi possível carregar suas contas conectadas. Verifique a configuração da integração.'
+        try {
+          const data = await response.json()
+          if (data?.error) {
+            message = data.error
+          }
+        } catch (parseError) {
+          console.error('Falha ao interpretar resposta de erro do Pluggy:', parseError)
+        }
+        throw new Error(message)
       }
 
       const json = await response.json()
@@ -57,11 +66,11 @@ export default function IntegrationsPage() {
       setAccounts(parsedAccounts)
     } catch (error) {
       console.error('Erro ao carregar contas Pluggy:', error)
-      toast.error(
-        'Erro ao carregar contas',
-        'Não foi possível carregar suas contas conectadas. Tente novamente em instantes.',
-        { duration: 5000 }
-      )
+      const description =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Não foi possível carregar suas contas conectadas. Tente novamente em instantes.'
+      toast.error('Erro ao carregar contas', description, { duration: 5000 })
     } finally {
       if (silent) {
         setRefreshing(false)

--- a/lib/crypto.ts
+++ b/lib/crypto.ts
@@ -1,12 +1,41 @@
 import crypto from 'crypto'
+
+export class EncryptionConfigError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'EncryptionConfigError'
+  }
+}
+
 const keyB64 = process.env.ENCRYPTION_KEY_BASE64 || ''
-if (!keyB64) console.warn('ENCRYPTION_KEY_BASE64 não definido!')
-const key = Buffer.from(keyB64, 'base64') // 32 bytes
-if (key.length !== 32) {
-  throw new Error('ENCRYPTION_KEY_BASE64 inválido: deve decodificar para 32 bytes')
+let cachedKey: Buffer | null = null
+let cachedKeyError: string | null = null
+
+if (!keyB64) {
+  cachedKeyError =
+    'ENCRYPTION_KEY_BASE64 ausente. Configure uma chave Base64 de 32 bytes (256 bits) para habilitar a criptografia.'
+  console.error(cachedKeyError)
+} else {
+  const decoded = Buffer.from(keyB64, 'base64')
+  if (decoded.length !== 32) {
+    cachedKeyError =
+      'ENCRYPTION_KEY_BASE64 inválido. Gere uma chave de 32 bytes, codifique em Base64 e defina a variável de ambiente.'
+    console.error(cachedKeyError)
+  } else {
+    cachedKey = decoded
+  }
+}
+
+function ensureEncryptionKey(): Buffer {
+  if (cachedKey) return cachedKey
+  throw new EncryptionConfigError(
+    cachedKeyError ||
+      'ENCRYPTION_KEY_BASE64 ausente ou inválido. Configure uma chave Base64 de 32 bytes (256 bits) para habilitar a criptografia.'
+  )
 }
 
 export function encryptJSON(obj: any): string {
+  const key = ensureEncryptionKey()
   const iv = crypto.randomBytes(12)
   const cipher = crypto.createCipheriv('aes-256-gcm', key, iv)
   const plaintext = Buffer.from(JSON.stringify(obj))
@@ -16,6 +45,7 @@ export function encryptJSON(obj: any): string {
 }
 
 export function decryptJSON(b64: string): any {
+  const key = ensureEncryptionKey()
   const buf = Buffer.from(b64, 'base64')
   const iv = buf.subarray(0, 12)
   const tag = buf.subarray(12, 28)

--- a/lib/pluggy-connect.ts
+++ b/lib/pluggy-connect.ts
@@ -25,11 +25,16 @@ export function createHandleConnect({ toast, onAfterSync }: CreateHandleConnectO
       }
 
       if (!response.ok) {
-        toast.error(
-          'Erro na conexão',
-          'Não foi possível iniciar a conexão bancária. Tente novamente em instantes.',
-          { duration: 5000 }
-        )
+        let message = 'Não foi possível iniciar a conexão bancária. Verifique a configuração das variáveis do Pluggy.'
+        try {
+          const data = await response.json()
+          if (data?.error) {
+            message = data.error
+          }
+        } catch (parseError) {
+          console.error('Falha ao interpretar resposta de erro (link-token):', parseError)
+        }
+        toast.error('Erro na conexão', message, { duration: 5000 })
         return
       }
 
@@ -71,7 +76,16 @@ export function createHandleConnect({ toast, onAfterSync }: CreateHandleConnectO
           }
 
           if (!resp.ok) {
-            throw new Error('Pluggy sync failed')
+            let syncMessage = 'Não foi possível sincronizar suas transações. Verifique a configuração da integração.'
+            try {
+              const data = await resp.json()
+              if (data?.error) {
+                syncMessage = data.error
+              }
+            } catch (parseError) {
+              console.error('Falha ao interpretar resposta de erro (sync):', parseError)
+            }
+            throw new Error(syncMessage)
           }
 
           await onAfterSync?.()
@@ -83,11 +97,11 @@ export function createHandleConnect({ toast, onAfterSync }: CreateHandleConnectO
           )
         } catch (error) {
           console.error('Erro ao sincronizar conta Pluggy:', error)
-          toast.error(
-            'Erro na sincronização',
-            'Não foi possível sincronizar suas transações. Tente novamente.',
-            { duration: 5000 }
-          )
+          const description =
+            error instanceof Error && error.message
+              ? error.message
+              : 'Não foi possível sincronizar suas transações. Tente novamente.'
+          toast.error('Erro na sincronização', description, { duration: 5000 })
         }
       })
 
@@ -103,11 +117,11 @@ export function createHandleConnect({ toast, onAfterSync }: CreateHandleConnectO
       connect.init()
     } catch (error) {
       console.error('Erro ao iniciar conexão Pluggy:', error)
-      toast.error(
-        'Erro na conexão',
-        'Não foi possível iniciar a conexão bancária. Tente novamente em instantes.',
-        { duration: 5000 }
-      )
+      const description =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Não foi possível iniciar a conexão bancária. Tente novamente em instantes.'
+      toast.error('Erro na conexão', description, { duration: 5000 })
     }
   }
 }

--- a/lib/pluggy.ts
+++ b/lib/pluggy.ts
@@ -1,18 +1,41 @@
 import axios from 'axios'
+
+export class ConfigurationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ConfigurationError'
+  }
+}
+
 const BASE_URL = process.env.PLUGGY_BASE_URL || 'https://api.pluggy.ai'
-const CLIENT_ID = process.env.PLUGGY_CLIENT_ID!
-const CLIENT_SECRET = process.env.PLUGGY_CLIENT_SECRET!
+const CLIENT_ID = process.env.PLUGGY_CLIENT_ID
+const CLIENT_SECRET = process.env.PLUGGY_CLIENT_SECRET
 
 let cachedApiKey: { key: string; exp: number } | null = null
 
 async function getApiKey(): Promise<string> {
   const now = Date.now()
   if (cachedApiKey && now < cachedApiKey.exp) return cachedApiKey.key
-  const { data } = await axios.post(`${BASE_URL}/auth`, { clientId: CLIENT_ID, clientSecret: CLIENT_SECRET })
+  const credentials = resolveCredentials()
+  const { data } = await axios.post(`${BASE_URL}/auth`, credentials)
   const key: string = data.apiKey || data.accessToken || data.token
   const ttlMs = (data.expiresIn ? Number(data.expiresIn) : 110 * 60) * 1000
   cachedApiKey = { key, exp: now + ttlMs }
   return key
+}
+
+function resolveCredentials(): { clientId: string; clientSecret: string } {
+  const clientId = CLIENT_ID?.trim()
+  const clientSecret = CLIENT_SECRET?.trim()
+
+  if (!clientId || !clientSecret) {
+    const message =
+      'PLUGGY_CLIENT_ID e/ou PLUGGY_CLIENT_SECRET não foram configurados. Defina as variáveis de ambiente antes de usar a integração.'
+    console.error(message)
+    throw new ConfigurationError(message)
+  }
+
+  return { clientId, clientSecret }
 }
 
 async function authHeaders() {


### PR DESCRIPTION
## Summary
- add explicit configuration error types for crypto and Pluggy clients so missing env vars only fail when used
- make Pluggy API routes surface configuration problems with 503 responses consumed by updated toasts
- document the expected error messages in the Pluggy section of the README for easier setup troubleshooting

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb44006828832fafb8a222a23faaab