### PR TITLE
Add manual account management and offline transaction support

### DIFF
--- a/app/api/manual-accounts/[id]/route.ts
+++ b/app/api/manual-accounts/[id]/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { Prisma } from '@prisma/client'
+
+import { prisma } from '@/lib/db'
+import { ensureUser } from '@/lib/ensure-user'
+
+const parseManualMetadata = (value: string | null) => {
+  if (!value) return null
+  try {
+    return JSON.parse(value) as Record<string, unknown>
+  } catch (error) {
+    console.warn('Falha ao interpretar metadata de conta manual:', error)
+    return null
+  }
+}
+
+const serializeManualAccount = (account: any) => {
+  const metadata = parseManualMetadata(account.dataEnc ?? null)
+  return {
+    id: account.id,
+    name: account.name,
+    currency: account.currency,
+    balance: Number(account.balance),
+    provider: account.provider,
+    type:
+      typeof metadata?.type === 'string'
+        ? metadata.type
+        : typeof account.providerItem === 'string'
+          ? account.providerItem
+          : null,
+    createdAt: account.createdAt.toISOString(),
+    updatedAt: account.updatedAt.toISOString(),
+  }
+}
+
+const validateStringField = (value: unknown, fieldName: string) => {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${fieldName} é obrigatório`)
+  }
+  return value.trim()
+}
+
+const validateBalance = (value: unknown) => {
+  if (value === undefined || value === null) {
+    throw new Error('Saldo é obrigatório')
+  }
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) {
+    throw new Error('Saldo inválido')
+  }
+  return numeric
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { userId } = auth()
+    if (!userId) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 })
+    }
+
+    await ensureUser(userId)
+
+    const account = await prisma.bankAccount.findFirst({
+      where: { id: params.id, userId, provider: 'manual' },
+    })
+
+    if (!account) {
+      return NextResponse.json({ error: 'Conta não encontrada' }, { status: 404 })
+    }
+
+    const body = await request.json()
+
+    const updateData: Record<string, unknown> = {}
+
+    if (body?.name !== undefined) {
+      updateData.name = validateStringField(body.name, 'Nome')
+    }
+
+    if (body?.currency !== undefined) {
+      updateData.currency = validateStringField(body.currency, 'Moeda')
+    }
+
+    if (body?.balance !== undefined) {
+      const balanceValue = validateBalance(body.balance)
+      updateData.balance = new Prisma.Decimal(balanceValue)
+    }
+
+    const type =
+      body?.type !== undefined
+        ? typeof body.type === 'string' && body.type.trim() !== ''
+          ? body.type.trim()
+          : null
+        : parseManualMetadata(account.dataEnc ?? null)?.type ?? null
+
+    updateData.providerItem = type || null
+    updateData.dataEnc = type ? JSON.stringify({ type }) : null
+
+    const updated = await prisma.bankAccount.update({
+      where: { id: params.id },
+      data: updateData,
+    })
+
+    return NextResponse.json(serializeManualAccount(updated))
+  } catch (error) {
+    console.error('Erro ao atualizar conta manual:', error)
+    const message = error instanceof Error ? error.message : 'Erro interno'
+    const status = message.includes('é obrigatório') || message.includes('inválido') ? 400 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}
+
+export async function DELETE(
+  _request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const { userId } = auth()
+    if (!userId) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 })
+    }
+
+    await ensureUser(userId)
+
+    const account = await prisma.bankAccount.findFirst({
+      where: { id: params.id, userId, provider: 'manual' },
+    })
+
+    if (!account) {
+      return NextResponse.json({ error: 'Conta não encontrada' }, { status: 404 })
+    }
+
+    await prisma.$transaction([
+      prisma.transaction.deleteMany({ where: { accountId: account.id, userId } }),
+      prisma.budgetItem.updateMany({
+        where: { accountId: account.id, budget: { userId } },
+        data: { accountId: null },
+      }),
+      prisma.bankAccount.delete({ where: { id: account.id } }),
+    ])
+
+    return NextResponse.json({ ok: true })
+  } catch (error) {
+    console.error('Erro ao remover conta manual:', error)
+    return NextResponse.json({ error: 'Erro interno' }, { status: 500 })
+  }
+}

--- a/app/api/manual-accounts/route.ts
+++ b/app/api/manual-accounts/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { auth } from '@clerk/nextjs/server'
+import { Prisma } from '@prisma/client'
+
+import { prisma } from '@/lib/db'
+import { ensureUser } from '@/lib/ensure-user'
+
+const parseManualMetadata = (value: string | null) => {
+  if (!value) return null
+  try {
+    return JSON.parse(value) as Record<string, unknown>
+  } catch (error) {
+    console.warn('Falha ao interpretar metadata de conta manual:', error)
+    return null
+  }
+}
+
+const serializeManualAccount = (account: any) => {
+  const metadata = parseManualMetadata(account.dataEnc ?? null)
+  return {
+    id: account.id,
+    name: account.name,
+    currency: account.currency,
+    balance: Number(account.balance),
+    provider: account.provider,
+    type:
+      typeof metadata?.type === 'string'
+        ? metadata.type
+        : typeof account.providerItem === 'string'
+          ? account.providerItem
+          : null,
+    createdAt: account.createdAt.toISOString(),
+    updatedAt: account.updatedAt.toISOString(),
+  }
+}
+
+const validateStringField = (value: unknown, fieldName: string) => {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${fieldName} é obrigatório`)
+  }
+  return value.trim()
+}
+
+const validateBalance = (value: unknown) => {
+  if (value === undefined || value === null) {
+    throw new Error('Saldo é obrigatório')
+  }
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) {
+    throw new Error('Saldo inválido')
+  }
+  return numeric
+}
+
+export async function GET() {
+  try {
+    const { userId } = auth()
+    if (!userId) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 })
+    }
+
+    await ensureUser(userId)
+
+    const accounts = await prisma.bankAccount.findMany({
+      where: { userId, provider: 'manual' },
+      orderBy: { createdAt: 'desc' },
+    })
+
+    return NextResponse.json(accounts.map(serializeManualAccount))
+  } catch (error) {
+    console.error('Erro ao listar contas manuais:', error)
+    return NextResponse.json({ error: 'Erro interno' }, { status: 500 })
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId } = auth()
+    if (!userId) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 })
+    }
+
+    await ensureUser(userId)
+
+    const body = await request.json()
+    const name = validateStringField(body?.name, 'Nome')
+    const currency = validateStringField(body?.currency, 'Moeda')
+    const balanceValue = validateBalance(body?.balance)
+    const type = typeof body?.type === 'string' ? body.type.trim() : null
+
+    const account = await prisma.bankAccount.create({
+      data: {
+        userId,
+        provider: 'manual',
+        name,
+        currency,
+        balance: new Prisma.Decimal(balanceValue),
+        providerItem: type || null,
+        dataEnc: type ? JSON.stringify({ type }) : null,
+      },
+    })
+
+    return NextResponse.json(serializeManualAccount(account), { status: 201 })
+  } catch (error) {
+    console.error('Erro ao criar conta manual:', error)
+    const message = error instanceof Error ? error.message : 'Erro interno'
+    const status = message.includes('é obrigatório') || message.includes('inválido') ? 400 : 500
+    return NextResponse.json({ error: message }, { status })
+  }
+}

--- a/app/api/pluggy/sync/route.ts
+++ b/app/api/pluggy/sync/route.ts
@@ -91,6 +91,16 @@ export async function POST(req: NextRequest) {
   }
 }
 
+const parseManualMetadata = (value: string | null | undefined) => {
+  if (!value) return null
+  try {
+    return JSON.parse(value) as Record<string, unknown>
+  } catch (error) {
+    console.warn('Falha ao interpretar metadata de conta manual:', error)
+    return null
+  }
+}
+
 export async function GET(req: NextRequest) {
   const { userId: uid } = auth()
   if (!uid) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -103,7 +113,12 @@ export async function GET(req: NextRequest) {
     })
     const accs = accounts.map((a) => ({
       ...a,
-      data: a.dataEnc ? decryptJSON(a.dataEnc) : null,
+      data:
+        a.provider === 'manual'
+          ? parseManualMetadata(a.dataEnc)
+          : a.dataEnc
+            ? decryptJSON(a.dataEnc)
+            : null,
     }))
     const txs = transactions.map((t) => ({
       ...t,

--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -7,6 +7,10 @@ import { LiquidButton } from '@/components/ui/liquid-button'
 import { useToast } from '@/hooks/use-toast'
 import { createHandleConnect } from '@/lib/pluggy-connect'
 import { formatCurrency, formatDateTime } from '@/lib/format-utils'
+import {
+  ManualAccountForm,
+  ManualAccountFormData,
+} from '@/components/forms/manual-account-form'
 
 interface BankAccount {
   id: string
@@ -21,12 +25,28 @@ interface BankAccount {
   data?: Record<string, any> | null
 }
 
+interface ManualAccount {
+  id: string
+  name: string
+  currency: string
+  balance: number
+  type?: string | null
+  createdAt: string
+  updatedAt: string
+}
+
 export default function IntegrationsPage() {
   const [accounts, setAccounts] = useState<BankAccount[]>([])
+  const [manualAccounts, setManualAccounts] = useState<ManualAccount[]>([])
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
   const [sdkReady, setSdkReady] = useState(false)
   const [disconnectingId, setDisconnectingId] = useState<string | null>(null)
+  const [manualAccountModalOpen, setManualAccountModalOpen] = useState(false)
+  const [manualAccountFormData, setManualAccountFormData] =
+    useState<ManualAccountFormData | null>(null)
+  const [savingManualAccount, setSavingManualAccount] = useState(false)
+  const [deletingManualAccountId, setDeletingManualAccountId] = useState<string | null>(null)
   const { toast } = useToast()
 
   const loadAccounts = useCallback(async ({ silent = false }: { silent?: boolean } = {}) => {
@@ -58,14 +78,52 @@ export default function IntegrationsPage() {
       }
 
       const json = await response.json()
-      const parsedAccounts = (json.accounts || []).map((account: any) => ({
-        ...account,
-        balance: Number(account.balance ?? 0),
-      })) as BankAccount[]
+      const parsedAccounts = (json.accounts || [])
+        .filter((account: any) => account.provider !== 'manual')
+        .map((account: any) => ({
+          ...account,
+          balance: Number(account.balance ?? 0),
+        })) as BankAccount[]
 
       setAccounts(parsedAccounts)
+
+      const manualResponse = await fetch('/api/manual-accounts')
+
+      if (manualResponse.status === 401) {
+        window.location.href = '/login'
+        return
+      }
+
+      if (!manualResponse.ok) {
+        let message = 'Não foi possível carregar suas contas offline.'
+        try {
+          const data = await manualResponse.json()
+          if (data?.error) {
+            message = data.error
+          }
+        } catch (parseError) {
+          console.error('Falha ao interpretar resposta de contas manuais:', parseError)
+        }
+        throw new Error(message)
+      }
+
+      const manualJson = await manualResponse.json()
+      const parsedManualAccounts = (Array.isArray(manualJson) ? manualJson : []).map(
+        (account: any) => ({
+          id: account.id,
+          name: account.name,
+          currency: account.currency,
+          balance: Number(account.balance ?? 0),
+          type: account.type ?? null,
+          createdAt: account.createdAt,
+          updatedAt: account.updatedAt,
+        })
+      ) as ManualAccount[]
+
+      setManualAccounts(parsedManualAccounts)
     } catch (error) {
       console.error('Erro ao carregar contas Pluggy:', error)
+      setManualAccounts([])
       const description =
         error instanceof Error && error.message
           ? error.message
@@ -136,6 +194,116 @@ export default function IntegrationsPage() {
       }
     },
     [toast, loadAccounts]
+  )
+
+  const handleOpenManualAccountModal = useCallback(
+    (account?: ManualAccount) => {
+      if (account) {
+        setManualAccountFormData({
+          id: account.id,
+          name: account.name,
+          currency: account.currency,
+          balance: account.balance,
+          type: account.type ?? null,
+        })
+      } else {
+        setManualAccountFormData(null)
+      }
+      setManualAccountModalOpen(true)
+    },
+    []
+  )
+
+  const closeManualAccountModal = useCallback(() => {
+    setManualAccountModalOpen(false)
+    setManualAccountFormData(null)
+    setSavingManualAccount(false)
+  }, [])
+
+  const handleSubmitManualAccount = useCallback(
+    async (values: ManualAccountFormData) => {
+      setSavingManualAccount(true)
+      const isEditing = Boolean(values.id)
+
+      try {
+        const response = await fetch(
+          isEditing ? `/api/manual-accounts/${values.id}` : '/api/manual-accounts',
+          {
+            method: isEditing ? 'PATCH' : 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              name: values.name,
+              type: values.type,
+              currency: values.currency,
+              balance: values.balance,
+            }),
+          }
+        )
+
+        if (!response.ok) {
+          throw new Error('Failed to save manual account')
+        }
+
+        toast.success(
+          isEditing ? 'Conta offline atualizada' : 'Conta offline criada',
+          isEditing
+            ? 'As alterações foram salvas com sucesso.'
+            : 'A conta manual foi adicionada com sucesso.'
+        )
+
+        closeManualAccountModal()
+        await loadAccounts({ silent: true })
+      } catch (error) {
+        console.error('Erro ao salvar conta manual:', error)
+        toast.error(
+          isEditing ? 'Erro ao atualizar conta offline' : 'Erro ao criar conta offline',
+          isEditing
+            ? 'Não foi possível salvar as alterações. Tente novamente.'
+            : 'Não foi possível adicionar a conta manual. Tente novamente.'
+        )
+      } finally {
+        setSavingManualAccount(false)
+      }
+    },
+    [closeManualAccountModal, loadAccounts, toast]
+  )
+
+  const handleDeleteManualAccount = useCallback(
+    async (accountId: string) => {
+      const confirmed = window.confirm(
+        'Tem certeza de que deseja remover esta conta offline? Todos os lançamentos associados serão apagados.'
+      )
+      if (!confirmed) {
+        return
+      }
+
+      setDeletingManualAccountId(accountId)
+      try {
+        const response = await fetch(`/api/manual-accounts/${accountId}`, {
+          method: 'DELETE',
+        })
+
+        if (!response.ok) {
+          throw new Error('Failed to delete manual account')
+        }
+
+        toast.success(
+          'Conta offline removida',
+          'A conta manual foi excluída com sucesso.'
+        )
+
+        await loadAccounts({ silent: true })
+      } catch (error) {
+        console.error('Erro ao remover conta manual:', error)
+        toast.error(
+          'Erro ao remover conta offline',
+          'Não foi possível excluir esta conta. Tente novamente.'
+        )
+      } finally {
+        setDeletingManualAccountId(null)
+      }
+    },
+    [loadAccounts, toast]
   )
 
   const connectButtonDisabled = !sdkReady || loading || refreshing
@@ -245,6 +413,112 @@ export default function IntegrationsPage() {
           )}
         </LiquidCard>
       </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.15 }}
+      >
+        <LiquidCard>
+          <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
+            <div>
+              <h2 className="text-xl font-semibold text-white">💼 Contas Offline</h2>
+              <p className="text-slate-400 text-sm mt-1">
+                Cadastre instituições que não possuem integração automática e acompanhe seus saldos manualmente.
+              </p>
+            </div>
+            <LiquidButton
+              onClick={() => handleOpenManualAccountModal()}
+              variant="primary"
+              glowColor="#22c55e"
+              disabled={savingManualAccount}
+            >
+              Nova conta offline
+            </LiquidButton>
+          </div>
+
+          {loading ? (
+            <div className="text-center py-12">
+              <div className="mx-auto mb-4 h-10 w-10 rounded-full border-2 border-emerald-400 border-b-transparent animate-spin"></div>
+              <p className="text-slate-400">Carregando contas offline...</p>
+            </div>
+          ) : manualAccounts.length === 0 ? (
+            <div className="text-center py-12 space-y-3">
+              <div className="text-6xl">🗂️</div>
+              <h3 className="text-lg font-semibold text-white">Nenhuma conta offline</h3>
+              <p className="text-slate-400 text-sm">
+                Registre suas contas manuais para acompanhar cartões, investimentos ou carteiras que não possuem Open Finance.
+              </p>
+              <LiquidButton
+                onClick={() => handleOpenManualAccountModal()}
+                variant="outline"
+                glowColor="#22c55e"
+                disabled={savingManualAccount}
+              >
+                Criar primeira conta manual
+              </LiquidButton>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {refreshing && (
+                <div className="flex items-center gap-2 text-xs text-slate-400">
+                  <span className="h-3 w-3 rounded-full border-2 border-slate-400 border-t-transparent animate-spin"></span>
+                  Atualizando contas offline...
+                </div>
+              )}
+              {manualAccounts.map((account) => (
+                <div
+                  key={account.id}
+                  className="flex flex-col gap-3 rounded-2xl border border-card-border/40 bg-card-glass/40 p-4 backdrop-blur-glass md:flex-row md:items-center md:justify-between"
+                >
+                  <div className="space-y-2">
+                    <div className="text-lg font-semibold text-white">{account.name}</div>
+                    <div className="text-sm font-medium text-slate-100">
+                      {formatCurrency(account.balance)}
+                    </div>
+                    <div className="text-xs text-slate-400">
+                      Moeda: {account.currency}
+                      {account.type ? ` · Tipo: ${account.type}` : ''}
+                    </div>
+                    <div className="text-xs text-slate-500">
+                      Atualizado em {formatDateTime(account.updatedAt)}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <LiquidButton
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handleOpenManualAccountModal(account)}
+                      disabled={savingManualAccount && manualAccountFormData?.id === account.id}
+                    >
+                      Editar
+                    </LiquidButton>
+                    <LiquidButton
+                      variant="outline"
+                      size="sm"
+                      className="text-red-400 border-red-500/40 hover:text-red-200 hover:border-red-300/60"
+                      onClick={() => handleDeleteManualAccount(account.id)}
+                      disabled={deletingManualAccountId === account.id}
+                    >
+                      {deletingManualAccountId === account.id ? 'Removendo...' : 'Excluir'}
+                    </LiquidButton>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </LiquidCard>
+      </motion.div>
+
+      {manualAccountModalOpen && (
+        <ManualAccountForm
+          open={manualAccountModalOpen}
+          account={manualAccountFormData}
+          onClose={closeManualAccountModal}
+          onSubmit={handleSubmitManualAccount}
+          submitting={savingManualAccount}
+        />
+      )}
     </motion.div>
   )
 }

--- a/components/forms/manual-account-form.tsx
+++ b/components/forms/manual-account-form.tsx
@@ -1,0 +1,234 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { motion } from 'framer-motion'
+
+import { LiquidCard } from '@/components/ui/liquid-card'
+import { LiquidButton } from '@/components/ui/liquid-button'
+import { LiquidInput } from '@/components/ui/liquid-input'
+
+export interface ManualAccountFormData {
+  id?: string
+  name: string
+  type?: string | null
+  currency: string
+  balance: number
+}
+
+interface ManualAccountFormProps {
+  account?: ManualAccountFormData | null
+  open: boolean
+  onClose: () => void
+  onSubmit: (values: ManualAccountFormData) => Promise<void> | void
+  submitting?: boolean
+}
+
+const DEFAULT_ACCOUNT_TYPES = [
+  { value: 'Conta Corrente', label: 'Conta Corrente' },
+  { value: 'Conta Poupança', label: 'Conta Poupança' },
+  { value: 'Cartão de Crédito', label: 'Cartão de Crédito' },
+  { value: 'Carteira', label: 'Carteira' },
+  { value: 'Outro', label: 'Outro' },
+]
+
+const DEFAULT_CURRENCIES = [
+  { value: 'BRL', label: 'Real (BRL)' },
+  { value: 'USD', label: 'Dólar (USD)' },
+  { value: 'EUR', label: 'Euro (EUR)' },
+]
+
+const createInitialState = (account?: ManualAccountFormData | null) => ({
+  id: account?.id,
+  name: account?.name ?? '',
+  type: account?.type ?? '',
+  currency: account?.currency ?? 'BRL',
+})
+
+const createInitialBalance = (account?: ManualAccountFormData | null) =>
+  account ? String(account.balance) : ''
+
+export function ManualAccountForm({
+  account,
+  open,
+  onClose,
+  onSubmit,
+  submitting,
+}: ManualAccountFormProps) {
+  const [formValues, setFormValues] = useState(() => createInitialState(account))
+  const [balanceInput, setBalanceInput] = useState(() => createInitialBalance(account))
+
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+
+    setFormValues(createInitialState(account))
+    setBalanceInput(createInitialBalance(account))
+  }, [open, account])
+
+  const isEditing = useMemo(() => Boolean(formValues.id), [formValues.id])
+  const isSubmitting = Boolean(submitting)
+
+  if (!open) {
+    return null
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (isSubmitting) return
+
+    const normalizedBalance = Number((balanceInput || '').replace(',', '.'))
+    if (!Number.isFinite(normalizedBalance)) {
+      window.alert('Informe um saldo inicial numérico válido.')
+      return
+    }
+
+    const trimmedName = formValues.name.trim()
+    if (!trimmedName) {
+      window.alert('O nome da conta é obrigatório.')
+      return
+    }
+
+    const payload: ManualAccountFormData = {
+      id: formValues.id,
+      name: trimmedName,
+      type: formValues.type?.trim() || null,
+      currency: formValues.currency,
+      balance: normalizedBalance,
+    }
+
+    onSubmit(payload)
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95 }}
+        animate={{ opacity: 1, scale: 1 }}
+        exit={{ opacity: 0, scale: 0.95 }}
+        className="w-full max-w-lg max-h-[90vh] overflow-y-auto"
+      >
+        <LiquidCard>
+          <form onSubmit={handleSubmit} className="space-y-6">
+            <div className="flex items-center justify-between mb-2">
+              <h3 className="text-xl font-semibold text-white">
+                {isEditing ? 'Editar conta offline' : 'Nova conta offline'}
+              </h3>
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-slate-400 hover:text-white transition-colors"
+                aria-label="Fechar"
+              >
+                ✕
+              </button>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-2">
+                Nome *
+              </label>
+              <LiquidInput
+                type="text"
+                value={formValues.name}
+                onChange={(event) =>
+                  setFormValues((prev) => ({
+                    ...prev,
+                    name: event.target.value,
+                  }))
+                }
+                placeholder="Ex: Banco XPTO"
+                required
+                disabled={isSubmitting}
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-2">
+                Tipo da conta
+              </label>
+              <select
+                className="w-full rounded-md border border-slate-700 bg-slate-900/70 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                value={formValues.type}
+                onChange={(event) =>
+                  setFormValues((prev) => ({
+                    ...prev,
+                    type: event.target.value,
+                  }))
+                }
+                disabled={isSubmitting}
+              >
+                <option value="">Selecionar tipo</option>
+                {DEFAULT_ACCOUNT_TYPES.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="grid md:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-slate-300 mb-2">
+                  Moeda *
+                </label>
+                <select
+                  className="w-full rounded-md border border-slate-700 bg-slate-900/70 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  value={formValues.currency}
+                  onChange={(event) =>
+                    setFormValues((prev) => ({
+                      ...prev,
+                      currency: event.target.value,
+                    }))
+                  }
+                  required
+                  disabled={isSubmitting}
+                >
+                  {DEFAULT_CURRENCIES.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-slate-300 mb-2">
+                  Saldo inicial *
+                </label>
+                <LiquidInput
+                  type="number"
+                  step="0.01"
+                  inputMode="decimal"
+                  value={balanceInput}
+                  onChange={(event) => setBalanceInput(event.target.value)}
+                  placeholder="0,00"
+                  required
+                  disabled={isSubmitting}
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-3 pt-2">
+              <LiquidButton
+                type="button"
+                variant="ghost"
+                onClick={onClose}
+                disabled={isSubmitting}
+              >
+                Cancelar
+              </LiquidButton>
+              <LiquidButton type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? 'Salvando...'
+                  : isEditing
+                    ? 'Salvar alterações'
+                    : 'Criar conta'}
+              </LiquidButton>
+            </div>
+          </form>
+        </LiquidCard>
+      </motion.div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add REST endpoints and forms to create, update, and delete manual bank accounts with persisted metadata
- update integrations and dashboard flows to manage offline accounts, open manual account modals, and pass selections into the transaction form
- require account selection in transaction APIs, adjust manual balances on create/update, and handle manual metadata when reading accounts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb4065a150832fae2e2433bff5e8b9