### PR TITLE
Remove unused format helpers and document SMTP test utility

### DIFF
--- a/lib/format-utils.ts
+++ b/lib/format-utils.ts
@@ -37,15 +37,6 @@ export function formatCurrency(value: number, showSymbol: boolean = true): strin
 }
 
 /**
- * Formata um número como moeda sem símbolo (1.234,56)
- * @param value - Valor a ser formatado
- * @returns String formatada sem símbolo de moeda
- */
-export function formatNumber(value: number): string {
-  return formatCurrency(value, false);
-}
-
-/**
  * Formata uma data no formato brasileiro (dd/MM/yyyy)
  * @param date - Data a ser formatada (string, Date ou timestamp)
  * @returns String formatada como dd/MM/yyyy
@@ -99,25 +90,6 @@ export function formatDateShort(date: string | Date | number): string {
   return new Intl.DateTimeFormat(PT_BR_LOCALE, {
     day: '2-digit',
     month: '2-digit',
-    timeZone: BRAZIL_TIME_ZONE
-  }).format(dateObj);
-}
-
-/**
- * Formata uma data de forma extensa (15 de setembro de 2025)
- * @param date - Data a ser formatada (string, Date ou timestamp)
- * @returns String formatada por extenso
- */
-export function formatDateLong(date: string | Date | number): string {
-  if (!date) return '--';
-  
-  const dateObj = new Date(date);
-  if (isNaN(dateObj.getTime())) return '--';
-
-  return new Intl.DateTimeFormat(PT_BR_LOCALE, {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric',
     timeZone: BRAZIL_TIME_ZONE
   }).format(dateObj);
 }
@@ -209,52 +181,6 @@ export function isUpcoming(date: string | Date | number, days: number = 7): bool
 }
 
 /**
- * Formata percentual brasileiro (12,34%)
- * @param value - Valor decimal (ex: 0.1234 para 12.34%)
- * @param decimals - Número de casas decimais (padrão: 2)
- * @returns String formatada como percentual
- */
-export function formatPercentage(value: number, decimals: number = 2): string {
-  if (value === null || value === undefined || isNaN(value)) {
-    return '0%';
-  }
-
-  return new Intl.NumberFormat(PT_BR_LOCALE, {
-    style: 'percent',
-    minimumFractionDigits: decimals,
-    maximumFractionDigits: decimals,
-  }).format(value);
-}
-
-/**
- * Formata status de vencimento com cores
- * @param date - Data a verificar
- * @returns Objeto com texto e classe CSS
- */
-export function getDateStatus(date: string | Date | number) {
-  if (isOverdue(date)) {
-    return {
-      text: 'Vencido',
-      className: 'text-red-400',
-      days: Math.abs(daysDifference(date))
-    };
-  } else if (isUpcoming(date)) {
-    const days = daysDifference(date);
-    return {
-      text: days === 0 ? 'Hoje' : `${days} dias`,
-      className: days <= 3 ? 'text-yellow-400' : 'text-blue-400',
-      days
-    };
-  } else {
-    return {
-      text: 'Em dia',
-      className: 'text-green-400',
-      days: daysDifference(date)
-    };
-  }
-}
-
-/**
  * Formata valor com indicação de positivo/negativo
  * @param value - Valor a ser formatado
  * @param showSign - Se deve mostrar o sinal + para valores positivos
@@ -263,7 +189,7 @@ export function getDateStatus(date: string | Date | number) {
 export function formatCurrencyWithSign(value: number, showSign: boolean = false) {
   const isPositive = value >= 0;
   const formatted = formatCurrency(Math.abs(value));
-  
+
   return {
     value: showSign && isPositive ? `+${formatted}` : (isPositive ? formatted : `-${formatted}`),
     className: isPositive ? 'text-green-400' : 'text-red-400',

--- a/lib/mailer.ts
+++ b/lib/mailer.ts
@@ -5,6 +5,10 @@ export const transporter = nodemailer.createTransport({
   secure: process.env.SMTP_SECURE === 'true',
   auth: process.env.SMTP_USER ? { user: process.env.SMTP_USER, pass: process.env.SMTP_PASS } : undefined,
 })
+/**
+ * Função utilitária para validar manualmente as credenciais SMTP.
+ * Mantida para o fluxo descrito no README (execução via `node -e "require('./lib/mailer').sendTest(...)"`).
+ */
 export async function sendTest(to: string) {
   return transporter.sendMail({ from: process.env.SMTP_FROM, to, subject: 'Teste Financeito', text: 'SMTP OK' })
 }


### PR DESCRIPTION
## Summary
- remove unused formatting helpers that were no longer referenced in the codebase
- document the SMTP test helper to clarify its manual verification purpose

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb5f41b4f4832f80abf999b1e940f3