### PR TITLE
Expand Pluggy sync coverage to credit cards, investments, and loans

### DIFF
--- a/app/api/pluggy/sync/route.ts
+++ b/app/api/pluggy/sync/route.ts
@@ -1,5 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { ConfigurationError, listAccounts, listTransactions } from '@/lib/pluggy'
+import {
+  ConfigurationError,
+  listAccounts,
+  listTransactions,
+  listCreditCards,
+  listCreditCardTransactions,
+  listInvestments,
+  listInvestmentTransactions,
+  listLoans,
+  listLoanTransactions,
+} from '@/lib/pluggy'
 import { EncryptionConfigError, encryptJSON, decryptJSON } from '@/lib/crypto'
 import { auth } from '@clerk/nextjs/server'
 import { prisma } from '@/lib/db'
@@ -80,6 +90,325 @@ export async function POST(req: NextRequest) {
       })
     }
 
+    const decimalOrNull = (value: unknown) => {
+      if (value === null || value === undefined) return null
+      if (value instanceof Prisma.Decimal) return value
+      if (typeof value === 'string') {
+        const trimmed = value.trim()
+        if (!trimmed) return null
+        const numeric = Number(trimmed)
+        if (Number.isNaN(numeric)) return null
+        return new Prisma.Decimal(trimmed)
+      }
+      if (typeof value === 'number') {
+        if (!Number.isFinite(value)) return null
+        return new Prisma.Decimal(value)
+      }
+      return null
+    }
+
+    const toDateOrNull = (value: unknown) => {
+      if (!value) return null
+      const date = new Date(value as any)
+      return Number.isNaN(date.getTime()) ? null : date
+    }
+
+    const toId = (value: unknown) => {
+      if (value === null || value === undefined) return null
+      return String(value)
+    }
+
+    const creditCardIds: string[] = []
+    try {
+      const ccResp = await listCreditCards({ itemId, pageSize: 500 })
+      const creditCards = ccResp.results || ccResp
+      for (const cc of creditCards) {
+        const providerResourceId = toId(cc.id ?? cc.creditCardId ?? cc.externalId)
+        if (!providerResourceId) continue
+        creditCardIds.push(providerResourceId)
+        const baseData = {
+          userId,
+          provider: 'pluggy',
+          itemId,
+          resourceType: 'credit_card',
+          providerResourceId,
+          accountId: cc.accountId ?? null,
+          name: cc.name || cc.displayName || cc.number || null,
+          category: cc.brand || cc.paymentNetwork || cc.type || null,
+          currency: cc.currencyCode || cc.currency || 'BRL',
+          amount: decimalOrNull(cc.availableCredit ?? cc.creditLimit ?? cc.limit),
+          balance: decimalOrNull(cc.balance ?? cc.currentBalance ?? cc.outstandingBalance),
+          dueDate: toDateOrNull(cc.dueDate ?? cc.nextDueDate ?? cc.dueDay),
+          dataEnc: encryptJSON(cc),
+        }
+        await prisma.pluggyResource.upsert({
+          where: {
+            provider_resourceType_providerResourceId: {
+              provider: 'pluggy',
+              resourceType: 'credit_card',
+              providerResourceId,
+            },
+          },
+          update: baseData,
+          create: baseData,
+        })
+
+        try {
+          const ccTxResp = await listCreditCardTransactions({ creditCardId: providerResourceId, pageSize: 500 })
+          const ccTransactions = ccTxResp.results || ccTxResp
+          for (const ccTx of ccTransactions) {
+            const txId = toId(ccTx.id ?? ccTx.transactionId ?? ccTx.externalId)
+            if (!txId) continue
+            creditCardIds.push(txId)
+            const txData = {
+              userId,
+              provider: 'pluggy',
+              itemId,
+              resourceType: 'credit_card_transaction',
+              providerResourceId: txId,
+              accountId: cc.accountId ?? null,
+              name: ccTx.description || ccTx.merchant || null,
+              category: ccTx.category || ccTx.type || null,
+              currency: ccTx.currencyCode || ccTx.currency || 'BRL',
+              amount: decimalOrNull(ccTx.amount ?? ccTx.value),
+              date: toDateOrNull(ccTx.date ?? ccTx.postingDate ?? ccTx.time),
+              dataEnc: encryptJSON({ ...ccTx, creditCardId: providerResourceId }),
+            }
+            await prisma.pluggyResource.upsert({
+              where: {
+                provider_resourceType_providerResourceId: {
+                  provider: 'pluggy',
+                  resourceType: 'credit_card_transaction',
+                  providerResourceId: txId,
+                },
+              },
+              update: txData,
+              create: txData,
+            })
+          }
+        } catch (error) {
+          console.warn('Falha ao sincronizar transações de cartão de crédito Pluggy:', error)
+        }
+      }
+    } catch (error) {
+      console.warn('Falha ao sincronizar cartões de crédito Pluggy:', error)
+    }
+
+    if (creditCardIds.length > 0) {
+      await prisma.pluggyResource.deleteMany({
+        where: {
+          userId,
+          provider: 'pluggy',
+          itemId,
+          resourceType: { in: ['credit_card', 'credit_card_transaction'] },
+          providerResourceId: { notIn: creditCardIds },
+        },
+      })
+    } else {
+      await prisma.pluggyResource.deleteMany({
+        where: {
+          userId,
+          provider: 'pluggy',
+          itemId,
+          resourceType: { in: ['credit_card', 'credit_card_transaction'] },
+        },
+      })
+    }
+
+    const investmentIds: string[] = []
+    try {
+      const invResp = await listInvestments({ itemId, pageSize: 500 })
+      const investments = invResp.results || invResp
+      for (const inv of investments) {
+        const providerResourceId = toId(inv.id ?? inv.investmentId ?? inv.externalId)
+        if (!providerResourceId) continue
+        investmentIds.push(providerResourceId)
+        const baseData = {
+          userId,
+          provider: 'pluggy',
+          itemId,
+          resourceType: 'investment',
+          providerResourceId,
+          accountId: inv.accountId ?? null,
+          name: inv.name || inv.security || inv.product || null,
+          category: inv.type || inv.subtype || null,
+          currency: inv.currencyCode || inv.currency || 'BRL',
+          amount: decimalOrNull(inv.quantity ?? inv.units),
+          balance: decimalOrNull(inv.balance ?? inv.marketValue ?? inv.value),
+          dataEnc: encryptJSON(inv),
+        }
+        await prisma.pluggyResource.upsert({
+          where: {
+            provider_resourceType_providerResourceId: {
+              provider: 'pluggy',
+              resourceType: 'investment',
+              providerResourceId,
+            },
+          },
+          update: baseData,
+          create: baseData,
+        })
+      }
+
+      try {
+        const invTxResp = await listInvestmentTransactions({ itemId, pageSize: 500 })
+        const investmentTransactions = invTxResp.results || invTxResp
+        for (const invTx of investmentTransactions) {
+          const txId = toId(invTx.id ?? invTx.transactionId ?? invTx.externalId)
+          if (!txId) continue
+          investmentIds.push(txId)
+          const txData = {
+            userId,
+            provider: 'pluggy',
+            itemId,
+            resourceType: 'investment_transaction',
+            providerResourceId: txId,
+            accountId: invTx.accountId ?? null,
+            name: invTx.description || invTx.security || invTx.product || null,
+            category: invTx.type || invTx.operationType || null,
+            currency: invTx.currencyCode || invTx.currency || 'BRL',
+            amount: decimalOrNull(invTx.amount ?? invTx.value),
+            balance: decimalOrNull(invTx.quantity ?? invTx.units),
+            date: toDateOrNull(invTx.date ?? invTx.operationDate ?? invTx.tradeDate),
+            dataEnc: encryptJSON(invTx),
+          }
+          await prisma.pluggyResource.upsert({
+            where: {
+              provider_resourceType_providerResourceId: {
+                provider: 'pluggy',
+                resourceType: 'investment_transaction',
+                providerResourceId: txId,
+              },
+            },
+            update: txData,
+            create: txData,
+          })
+        }
+      } catch (error) {
+        console.warn('Falha ao sincronizar transações de investimentos Pluggy:', error)
+      }
+    } catch (error) {
+      console.warn('Falha ao sincronizar investimentos Pluggy:', error)
+    }
+
+    if (investmentIds.length > 0) {
+      await prisma.pluggyResource.deleteMany({
+        where: {
+          userId,
+          provider: 'pluggy',
+          itemId,
+          resourceType: { in: ['investment', 'investment_transaction'] },
+          providerResourceId: { notIn: investmentIds },
+        },
+      })
+    } else {
+      await prisma.pluggyResource.deleteMany({
+        where: {
+          userId,
+          provider: 'pluggy',
+          itemId,
+          resourceType: { in: ['investment', 'investment_transaction'] },
+        },
+      })
+    }
+
+    const loanIds: string[] = []
+    try {
+      const loanResp = await listLoans({ itemId, pageSize: 500 })
+      const loans = loanResp.results || loanResp
+      for (const loan of loans) {
+        const providerResourceId = toId(loan.id ?? loan.loanId ?? loan.externalId)
+        if (!providerResourceId) continue
+        loanIds.push(providerResourceId)
+        const baseData = {
+          userId,
+          provider: 'pluggy',
+          itemId,
+          resourceType: 'loan',
+          providerResourceId,
+          accountId: loan.accountId ?? null,
+          name: loan.name || loan.product || loan.type || null,
+          category: loan.subtype || loan.category || null,
+          currency: loan.currencyCode || loan.currency || 'BRL',
+          amount: decimalOrNull(loan.installmentAmount ?? loan.paymentAmount),
+          balance: decimalOrNull(loan.balance ?? loan.remainingBalance ?? loan.principal),
+          dueDate: toDateOrNull(loan.nextDueDate ?? loan.dueDate ?? loan.endDate),
+          dataEnc: encryptJSON(loan),
+        }
+        await prisma.pluggyResource.upsert({
+          where: {
+            provider_resourceType_providerResourceId: {
+              provider: 'pluggy',
+              resourceType: 'loan',
+              providerResourceId,
+            },
+          },
+          update: baseData,
+          create: baseData,
+        })
+
+        try {
+          const loanTxResp = await listLoanTransactions({ loanId: providerResourceId, pageSize: 500 })
+          const loanTransactions = loanTxResp.results || loanTxResp
+          for (const loanTx of loanTransactions) {
+            const txId = toId(loanTx.id ?? loanTx.transactionId ?? loanTx.externalId)
+            if (!txId) continue
+            loanIds.push(txId)
+            const txData = {
+              userId,
+              provider: 'pluggy',
+              itemId,
+              resourceType: 'loan_transaction',
+              providerResourceId: txId,
+              accountId: loan.accountId ?? loanTx.accountId ?? null,
+              name: loanTx.description || loanTx.type || null,
+              category: loanTx.category || loanTx.subtype || null,
+              currency: loanTx.currencyCode || loanTx.currency || 'BRL',
+              amount: decimalOrNull(loanTx.amount ?? loanTx.value),
+              date: toDateOrNull(loanTx.date ?? loanTx.postingDate ?? loanTx.time),
+              dataEnc: encryptJSON({ ...loanTx, loanId: providerResourceId }),
+            }
+            await prisma.pluggyResource.upsert({
+              where: {
+                provider_resourceType_providerResourceId: {
+                  provider: 'pluggy',
+                  resourceType: 'loan_transaction',
+                  providerResourceId: txId,
+                },
+              },
+              update: txData,
+              create: txData,
+            })
+          }
+        } catch (error) {
+          console.warn('Falha ao sincronizar parcelas de empréstimo Pluggy:', error)
+        }
+      }
+    } catch (error) {
+      console.warn('Falha ao sincronizar empréstimos Pluggy:', error)
+    }
+
+    if (loanIds.length > 0) {
+      await prisma.pluggyResource.deleteMany({
+        where: {
+          userId,
+          provider: 'pluggy',
+          itemId,
+          resourceType: { in: ['loan', 'loan_transaction'] },
+          providerResourceId: { notIn: loanIds },
+        },
+      })
+    } else {
+      await prisma.pluggyResource.deleteMany({
+        where: {
+          userId,
+          provider: 'pluggy',
+          itemId,
+          resourceType: { in: ['loan', 'loan_transaction'] },
+        },
+      })
+    }
+
     return NextResponse.json({ ok: true })
   } catch (error) {
     if (error instanceof ConfigurationError || error instanceof EncryptionConfigError) {
@@ -124,7 +453,24 @@ export async function GET(req: NextRequest) {
       ...t,
       raw: t.rawEnc ? decryptJSON(t.rawEnc) : null,
     }))
-    return NextResponse.json({ accounts: accs, transactions: txs })
+    const resources = await prisma.pluggyResource.findMany({ where: { userId: uid } })
+    const resourcesWithData = resources.map((resource) => ({
+      ...resource,
+      data: resource.dataEnc ? decryptJSON(resource.dataEnc) : null,
+    }))
+    const resourcesByType = (type: string) =>
+      resourcesWithData.filter((resource) => resource.resourceType === type)
+
+    return NextResponse.json({
+      accounts: accs,
+      transactions: txs,
+      creditCards: resourcesByType('credit_card'),
+      creditCardTransactions: resourcesByType('credit_card_transaction'),
+      investments: resourcesByType('investment'),
+      investmentTransactions: resourcesByType('investment_transaction'),
+      loans: resourcesByType('loan'),
+      loanTransactions: resourcesByType('loan_transaction'),
+    })
   } catch (error) {
     if (error instanceof EncryptionConfigError) {
       console.error('Falha de configuração ao ler dados Pluggy:', error)
@@ -160,6 +506,19 @@ export async function DELETE(req: NextRequest) {
       where: { accountId, budget: { userId } },
       data: { accountId: null },
     })
+    if (account.provider === 'pluggy') {
+      const deletionFilters = [{ accountId }]
+      if (account.providerItem) {
+        deletionFilters.push({ itemId: account.providerItem })
+      }
+      await prisma.pluggyResource.deleteMany({
+        where: {
+          userId,
+          provider: 'pluggy',
+          OR: deletionFilters,
+        },
+      })
+    }
     await prisma.bankAccount.delete({ where: { id: accountId } })
   } catch (error) {
     console.error('Erro ao desconectar conta Pluggy:', error)

--- a/lib/pluggy.ts
+++ b/lib/pluggy.ts
@@ -65,3 +65,49 @@ export async function listAccounts(params: { itemId?: string; page?: number; pag
   const { data } = await axios.get(`${BASE_URL}/accounts`, { params, headers })
   return data
 }
+
+export async function listCreditCards(params: { itemId?: string; page?: number; pageSize?: number }) {
+  const headers = await authHeaders()
+  const { data } = await axios.get(`${BASE_URL}/credit_cards`, { params, headers })
+  return data
+}
+
+export async function listCreditCardTransactions(params: { creditCardId: string; page?: number; pageSize?: number }) {
+  const { creditCardId, ...rest } = params
+  if (!creditCardId) throw new Error('creditCardId is required')
+  const headers = await authHeaders()
+  const { data } = await axios.get(`${BASE_URL}/credit_cards/${creditCardId}/transactions`, {
+    params: rest,
+    headers,
+  })
+  return data
+}
+
+export async function listInvestments(params: { itemId?: string; page?: number; pageSize?: number }) {
+  const headers = await authHeaders()
+  const { data } = await axios.get(`${BASE_URL}/investments`, { params, headers })
+  return data
+}
+
+export async function listInvestmentTransactions(params: { itemId?: string; page?: number; pageSize?: number }) {
+  const headers = await authHeaders()
+  const { data } = await axios.get(`${BASE_URL}/investments/transactions`, { params, headers })
+  return data
+}
+
+export async function listLoans(params: { itemId?: string; page?: number; pageSize?: number }) {
+  const headers = await authHeaders()
+  const { data } = await axios.get(`${BASE_URL}/loans`, { params, headers })
+  return data
+}
+
+export async function listLoanTransactions(params: { loanId: string; page?: number; pageSize?: number }) {
+  const { loanId, ...rest } = params
+  if (!loanId) throw new Error('loanId is required')
+  const headers = await authHeaders()
+  const { data } = await axios.get(`${BASE_URL}/loans/${loanId}/transactions`, {
+    params: rest,
+    headers,
+  })
+  return data
+}

--- a/prisma/migrations/20250926090000_add_pluggy_resources/migration.sql
+++ b/prisma/migrations/20250926090000_add_pluggy_resources/migration.sql
@@ -1,0 +1,33 @@
+CREATE TABLE "PluggyResource" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "provider" TEXT NOT NULL,
+    "itemId" TEXT NOT NULL,
+    "resourceType" TEXT NOT NULL,
+    "providerResourceId" TEXT NOT NULL,
+    "accountId" TEXT,
+    "name" TEXT,
+    "category" TEXT,
+    "currency" TEXT,
+    "amount" DECIMAL(18,2),
+    "balance" DECIMAL(18,2),
+    "dueDate" TIMESTAMP(3),
+    "date" TIMESTAMP(3),
+    "dataEnc" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL
+);
+
+ALTER TABLE "PluggyResource"
+  ADD CONSTRAINT "PluggyResource_pkey" PRIMARY KEY ("id");
+
+CREATE UNIQUE INDEX "PluggyResource_provider_resourceType_providerResourceId_key"
+  ON "PluggyResource"("provider", "resourceType", "providerResourceId");
+
+CREATE INDEX "PluggyResource_userId_resourceType_idx"
+  ON "PluggyResource"("userId", "resourceType");
+
+ALTER TABLE "PluggyResource"
+  ADD CONSTRAINT "PluggyResource_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id")
+  ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model User {
   loans          Loan[]
   accounts       Account[]
   sessions       Session[]
+  pluggyResources PluggyResource[]
 }
 
 model BankAccount {
@@ -174,4 +175,28 @@ model VerificationToken {
   expires    DateTime
 
   @@unique([identifier, token])
+}
+
+model PluggyResource {
+  id                 String   @id @default(cuid())
+  userId             String
+  user               User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  provider           String
+  itemId             String
+  resourceType       String
+  providerResourceId String
+  accountId          String?
+  name               String?
+  category           String?
+  currency           String?
+  amount             Decimal? @db.Decimal(18, 2)
+  balance            Decimal? @db.Decimal(18, 2)
+  dueDate            DateTime?
+  date               DateTime?
+  dataEnc            String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  @@unique([provider, resourceType, providerResourceId])
+  @@index([userId, resourceType])
 }


### PR DESCRIPTION
## Summary
- add a PluggyResource Prisma model and migration to persist encrypted credit card, investment, and loan data from Pluggy
- extend the Pluggy sync route to collect cards, investments, loans, and their transactions while cleaning up removed records
- expose new Pluggy client helpers for credit cards, investments, and loans and surface the enriched data in the sync GET endpoint

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb628e56c8832fb3c9548ada91e3a6