### PR TITLE
feat: add admin deploy trigger from settings

### DIFF
--- a/app/api/admin/deploy/route.ts
+++ b/app/api/admin/deploy/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server'
+import { auth, clerkClient } from '@clerk/nextjs/server'
+import { promisify } from 'node:util'
+import { execFile } from 'node:child_process'
+import path from 'node:path'
+import fs from 'node:fs/promises'
+
+const execFileAsync = promisify(execFile)
+
+const DEPLOY_TIMEOUT_MS = Number(process.env.DEPLOY_TIMEOUT_MS ?? 10 * 60 * 1000)
+const rawAllowedEmails = process.env.DEPLOY_ALLOWED_EMAILS
+const allowedEmails = rawAllowedEmails
+  ? rawAllowedEmails
+      .split(',')
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean)
+  : null
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+
+async function resolveUserEmail(userId: string) {
+  const user = await clerkClient.users.getUser(userId)
+  const primaryEmail =
+    user.emailAddresses.find((address) => address.id === user.primaryEmailAddressId)?.emailAddress ??
+    user.emailAddresses[0]?.emailAddress ??
+    null
+
+  return primaryEmail ? primaryEmail.toLowerCase() : null
+}
+
+export async function POST() {
+  try {
+    const { userId } = auth()
+
+    if (!userId) {
+      return NextResponse.json({ error: 'Não autorizado' }, { status: 401 })
+    }
+
+    const email = await resolveUserEmail(userId)
+
+    if (allowedEmails && (!email || !allowedEmails.includes(email))) {
+      return NextResponse.json({ error: 'Usuário sem permissão para deploy' }, { status: 403 })
+    }
+
+    const scriptPath = path.join(process.cwd(), 'scripts', 'deploy.sh')
+
+    try {
+      await fs.access(scriptPath)
+    } catch {
+      return NextResponse.json(
+        { error: 'Script de deploy não encontrado no servidor', success: false },
+        { status: 500 }
+      )
+    }
+
+    const { stdout, stderr } = await execFileAsync(scriptPath, {
+      cwd: process.cwd(),
+      timeout: DEPLOY_TIMEOUT_MS,
+      maxBuffer: 10 * 1024 * 1024,
+    })
+
+    return NextResponse.json({ success: true, stdout, stderr })
+  } catch (error: unknown) {
+    console.error('Erro ao executar deploy:', error)
+
+    const execError = error as { stdout?: unknown; stderr?: unknown; message?: unknown }
+    const stdout = typeof execError?.stdout === 'string' ? execError.stdout : undefined
+    const stderr = typeof execError?.stderr === 'string' ? execError.stderr : undefined
+    const message =
+      typeof execError?.message === 'string'
+        ? execError.message
+        : error instanceof Error
+          ? error.message
+          : 'Erro desconhecido'
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: message,
+        stdout,
+        stderr,
+      },
+      { status: 500 }
+    )
+  }
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { DeployButton } from '@/components/settings/deploy-button'
 
 export const metadata: Metadata = {
   title: 'Configurações | Financeito',
@@ -22,6 +23,23 @@ export default function SettingsPage() {
           <Button asChild variant="outline">
             <Link href="/dashboard">Voltar ao dashboard</Link>
           </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Atualização do servidor</CardTitle>
+          <CardDescription>
+            Execute um deploy remoto para aplicar alterações commitadas no repositório e reiniciar os contêineres.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Este recurso está disponível apenas para administradores autorizados. Configure a variável{' '}
+            <code className="mx-1 rounded bg-muted px-1 py-0.5 text-xs">DEPLOY_ALLOWED_EMAILS</code>{' '}
+            com os e-mails que podem acionar o processo.
+          </p>
+          <DeployButton />
         </CardContent>
       </Card>
     </div>

--- a/components/settings/deploy-button.tsx
+++ b/components/settings/deploy-button.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+
+type DeployResult = {
+  success: boolean
+  error?: string
+  stdout?: string
+  stderr?: string
+}
+
+export function DeployButton() {
+  const [isLoading, setIsLoading] = useState(false)
+  const [lastResult, setLastResult] = useState<DeployResult | null>(null)
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null)
+
+  const handleDeploy = async () => {
+    setIsLoading(true)
+    setLastResult(null)
+
+    try {
+      const response = await fetch('/api/admin/deploy', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+
+      const data = (await response.json()) as DeployResult
+
+      setLastResult({ ...data, success: response.ok && data.success })
+      setLastUpdatedAt(new Date())
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Erro desconhecido'
+      setLastResult({ success: false, error: message })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const renderStatus = () => {
+    if (!lastResult) {
+      return null
+    }
+
+    if (lastResult.success) {
+      return (
+        <div className="rounded-md border border-green-500/30 bg-green-500/10 p-3 text-sm">
+          <p className="font-semibold text-green-500">Deploy executado com sucesso.</p>
+          {lastUpdatedAt ? (
+            <p className="text-xs text-muted-foreground">
+              Última execução em {lastUpdatedAt.toLocaleString('pt-BR')}
+            </p>
+          ) : null}
+          {lastResult.stdout ? (
+            <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words text-xs text-foreground">
+              {lastResult.stdout.trim()}
+            </pre>
+          ) : null}
+          {lastResult.stderr ? (
+            <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words text-xs text-foreground">
+              {lastResult.stderr.trim()}
+            </pre>
+          ) : null}
+        </div>
+      )
+    }
+
+    return (
+      <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm">
+        <p className="font-semibold text-destructive">Falha ao executar o deploy.</p>
+        {lastUpdatedAt ? (
+          <p className="text-xs text-muted-foreground">
+            Tentativa em {lastUpdatedAt.toLocaleString('pt-BR')}
+          </p>
+        ) : null}
+        {lastResult.error ? (
+          <p className="mt-2 whitespace-pre-wrap break-words text-xs text-foreground">
+            {lastResult.error}
+          </p>
+        ) : null}
+        {lastResult.stdout ? (
+          <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words text-xs text-foreground">
+            {lastResult.stdout.trim()}
+          </pre>
+        ) : null}
+        {lastResult.stderr ? (
+          <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words text-xs text-foreground">
+            {lastResult.stderr.trim()}
+          </pre>
+        ) : null}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <Button onClick={handleDeploy} disabled={isLoading}>
+        {isLoading ? 'Atualizando servidor…' : 'Atualizar servidor agora'}
+      </Button>
+      {isLoading ? <p className="text-xs text-muted-foreground">Executando comandos no servidor…</p> : null}
+      {renderStatus()}
+    </div>
+  )
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+printf '==> Verificando estado do repositório\n'
+if [[ -n "$(git status --porcelain)" ]]; then
+  printf 'Há alterações locais não commitadas. Abortando atualização.\n' >&2
+  exit 1
+fi
+
+printf '==> Buscando atualizações remotas\n'
+git fetch --all --prune
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+printf '==> Atualizando branch %s\n' "$CURRENT_BRANCH"
+git pull --ff-only
+
+printf '==> Recriando contêineres Docker (db, web, backup)\n'
+docker compose up -d --build db web backup
+
+printf '==> Estado atual dos contêineres\n'
+docker compose ps
+
+printf '==> Deploy concluído com sucesso.\n'


### PR DESCRIPTION
## Summary
- add a secured admin API endpoint that runs the server-side deploy script with Clerk authentication
- surface a deploy control card in the settings UI with status feedback for admins
- provide a reusable deploy.sh helper to pull the repository and rebuild docker services

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb6566ae34832f95727c4e996dcc27