### PR TITLE
Handle currentAmount in goal creation

### DIFF
--- a/__tests__/ensure-user-route.test.ts
+++ b/__tests__/ensure-user-route.test.ts
@@ -107,6 +107,7 @@ describe('ensureUser integration in goal route', () => {
       body: JSON.stringify({
         title: 'New Goal',
         targetAmount: 100,
+        currentAmount: 25,
         targetDate: '2024-12-31T00:00:00.000Z',
       }),
     })
@@ -116,11 +117,13 @@ describe('ensureUser integration in goal route', () => {
     expect(response.status).toBe(201)
     const payload = await response.json()
     expect(payload.title).toBe('New Goal')
+    expect(payload.currentAmount).toBe(25)
 
     expect(userUpsertMock).toHaveBeenCalledTimes(1)
     expect(goalCreateMock).toHaveBeenCalledTimes(1)
     expect(userStore.has('user_123')).toBe(true)
     expect(goalStore).toHaveLength(1)
     expect(goalStore[0].userId).toBe('user_123')
+    expect(goalStore[0].currentAmount).toBe(25)
   })
 })

--- a/app/api/goals/route.ts
+++ b/app/api/goals/route.ts
@@ -37,7 +37,16 @@ export async function POST(request: NextRequest) {
     }
 
     const data = await request.json()
-    const { title, description, targetAmount, currency, targetDate, category, priority } = data
+    const {
+      title,
+      description,
+      targetAmount,
+      currentAmount,
+      currency,
+      targetDate,
+      category,
+      priority
+    } = data
 
     // Validate required fields
     if (!title || !targetAmount || !targetDate) {
@@ -51,6 +60,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Campo targetAmount inválido' }, { status: 400 })
     }
 
+    const currentAmountNumber = currentAmount !== undefined ? Number(currentAmount) : 0
+    if (Number.isNaN(currentAmountNumber)) {
+      return NextResponse.json({ error: 'Campo currentAmount inválido' }, { status: 400 })
+    }
+
     // Create goal
     const goal = await prisma.goal.create({
       data: {
@@ -58,6 +72,7 @@ export async function POST(request: NextRequest) {
         title,
         description,
         targetAmount: targetAmountNumber,
+        currentAmount: currentAmountNumber,
         currency: currency || 'BRL',
         targetDate: new Date(targetDate),
         category,


### PR DESCRIPTION
## Summary
- parse the currentAmount field from goal creation requests and validate the numeric value
- persist the initial currentAmount in Prisma and keep numeric serialization in the response
- expand the ensure-user integration test to cover creating a goal with a non-zero currentAmount

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb6be9b624832f9daf11e0113c2209