### PR TITLE
Fix Pluggy deletion filter typing and resolve build type checks

### DIFF
--- a/app/api/pluggy/sync/route.ts
+++ b/app/api/pluggy/sync/route.ts
@@ -507,7 +507,7 @@ export async function DELETE(req: NextRequest) {
       data: { accountId: null },
     })
     if (account.provider === 'pluggy') {
-      const deletionFilters = [{ accountId }]
+      const deletionFilters: Prisma.PluggyResourceWhereInput[] = [{ accountId }]
       if (account.providerItem) {
         deletionFilters.push({ itemId: account.providerItem })
       }

--- a/app/api/transactions/[id]/route.ts
+++ b/app/api/transactions/[id]/route.ts
@@ -110,7 +110,8 @@ export async function PUT(
         ? accountId.trim()
         : ''
 
-    let targetAccount = existingTransaction.bankAccount
+    let targetAccount: typeof existingTransaction.bankAccount | null =
+      existingTransaction.bankAccount
 
     if (trimmedAccountId) {
       targetAccount = await prisma.bankAccount.findFirst({

--- a/components/ui/confirm-delete-modal.tsx
+++ b/components/ui/confirm-delete-modal.tsx
@@ -37,18 +37,19 @@ export function ConfirmDeleteModal({
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <LiquidCard
-        className="max-w-md w-full m-4"
+      <div
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
         aria-describedby={descriptionId}
+        className="max-w-md w-full m-4"
       >
-        <h3 id={titleId} className="text-xl font-semibold mb-4 text-white">
-          {title}
-        </h3>
-        <p id={descriptionId} className="text-slate-400 mb-6">
-          {message}
+        <LiquidCard className="w-full">
+          <h3 id={titleId} className="text-xl font-semibold mb-4 text-white">
+            {title}
+          </h3>
+          <p id={descriptionId} className="text-slate-400 mb-6">
+            {message}
         </p>
         <div className="flex gap-3">
           <LiquidButton
@@ -66,7 +67,8 @@ export function ConfirmDeleteModal({
             {confirmLabel}
           </LiquidButton>
         </div>
-      </LiquidCard>
+        </LiquidCard>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- explicitly type the Pluggy deletion filter array so Prisma accepts both account and item filters
- widen transaction account handling to allow nullable lookups during updates
- wrap the confirm delete modal contents with an accessible dialog container instead of placing aria props on LiquidCard

## Testing
- npm run build *(fails: requires Clerk publishable key and encryption key environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6ccd4618832fbdb9969e6923707c