### PR TITLE
Fix Prisma filter typing in Pluggy account deletion

### DIFF
--- a/app/api/pluggy/sync/route.ts
+++ b/app/api/pluggy/sync/route.ts
@@ -507,7 +507,8 @@ export async function DELETE(req: NextRequest) {
       data: { accountId: null },
     })
     if (account.provider === 'pluggy') {
-      const deletionFilters: Prisma.PluggyResourceWhereInput[] = [{ accountId }]
+      const deletionFilters: Prisma.PluggyResourceWhereInput[] = []
+      deletionFilters.push({ accountId })
       if (account.providerItem) {
         deletionFilters.push({ itemId: account.providerItem })
       }


### PR DESCRIPTION
## Summary
- ensure the Pluggy resource deletion filters array is explicitly typed before items are added

## Testing
- npm run build *(fails: @clerk/nextjs requires a publishableKey in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc256fc284832f89ddb30040a7d08d