### PR TITLE
Disable Pluggy connect buttons until SDK ready

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -511,10 +511,12 @@ export default function Dashboard() {
     { title: 'Empréstimos', description: 'Gerencie seus empréstimos', href: '/loans' },
   ]
 
+  const connectDisabled = !sdkReady || loading
+
   const quickActions: QuickAction[] = [
     { title: 'Nova Transação', onClick: handleOpenNewTransactionModal },
     { title: 'Nova Conta Offline', onClick: handleOpenManualAccountModal },
-    { title: 'Conectar Conta', onClick: handleConnect },
+    { title: 'Conectar Conta', onClick: handleConnect, disabled: connectDisabled },
     { title: 'Adicionar Meta', onClick: () => router.push('/goals?create=1') },
     { title: 'Novo Orçamento', onClick: () => router.push('/budget?create=1') },
   ]
@@ -686,7 +688,7 @@ export default function Dashboard() {
                 </div>
               </>
             ) : accounts.length === 0 ? (
-              <EmptyAccounts onConnect={handleConnect} />
+              <EmptyAccounts onConnect={handleConnect} disabled={connectDisabled} />
             ) : (
               <>
                 <div className="mb-4" style={{ width: '100%', height: 200 }}>
@@ -713,7 +715,7 @@ export default function Dashboard() {
                 </ul>
               </>
             )}
-            <LiquidButton onClick={handleConnect} disabled={!sdkReady || loading}>
+            <LiquidButton onClick={handleConnect} disabled={connectDisabled}>
               {loading ? 'Carregando...' : 'Conectar Conta'}
             </LiquidButton>
           </LiquidCard>
@@ -734,7 +736,7 @@ export default function Dashboard() {
                 </div>
               </>
             ) : transactions.length === 0 ? (
-              <EmptyTransactions onConnect={handleConnect} />
+              <EmptyTransactions onConnect={handleConnect} disabled={connectDisabled} />
             ) : (
               <>
                 <div style={{ width: '100%', height: 200 }}>

--- a/components/quick-actions.tsx
+++ b/components/quick-actions.tsx
@@ -7,6 +7,7 @@ export interface QuickAction {
   title: string
   href?: string
   onClick?: () => void
+  disabled?: boolean
 }
 
 interface QuickActionsProps {
@@ -29,6 +30,7 @@ export function QuickActions({ actions }: QuickActionsProps) {
             size="sm"
             variant="primary"
             onClick={action.onClick}
+            disabled={action.disabled}
           >
             {action.title}
           </LiquidButton>

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -10,16 +10,18 @@ interface EmptyStateProps {
   onAction?: () => void
   actionHref?: string
   className?: string
+  disabled?: boolean
 }
 
-export function EmptyState({ 
-  icon = "📋", 
-  title, 
-  description, 
-  actionText, 
-  onAction, 
+export function EmptyState({
+  icon = "📋",
+  title,
+  description,
+  actionText,
+  onAction,
   actionHref,
-  className = ""
+  className = "",
+  disabled = false
 }: EmptyStateProps) {
   return (
     <motion.div
@@ -36,6 +38,7 @@ export function EmptyState({
           onClick={onAction}
           variant="primary"
           className={actionHref ? "inline-block" : ""}
+          disabled={disabled}
         >
           {actionHref ? (
             <a href={actionHref}>{actionText}</a>
@@ -49,7 +52,12 @@ export function EmptyState({
 }
 
 // Estados vazios específicos para cada seção
-export function EmptyTransactions({ onConnect }: { onConnect?: () => void }) {
+interface EmptyConnectStateProps {
+  onConnect?: () => void
+  disabled?: boolean
+}
+
+export function EmptyTransactions({ onConnect, disabled }: EmptyConnectStateProps) {
   return (
     <EmptyState
       icon="💳"
@@ -57,11 +65,12 @@ export function EmptyTransactions({ onConnect }: { onConnect?: () => void }) {
       description="Conecte suas contas bancárias para ver suas transações automaticamente ou adicione transações manualmente."
       actionText="Conectar Conta"
       onAction={onConnect}
+      disabled={disabled}
     />
   )
 }
 
-export function EmptyAccounts({ onConnect }: { onConnect?: () => void }) {
+export function EmptyAccounts({ onConnect, disabled }: EmptyConnectStateProps) {
   return (
     <EmptyState
       icon="🏦"
@@ -69,6 +78,7 @@ export function EmptyAccounts({ onConnect }: { onConnect?: () => void }) {
       description="Conecte suas contas bancárias para começar a acompanhar seu saldo e transações em tempo real."
       actionText="Conectar Primeira Conta"
       onAction={onConnect}
+      disabled={disabled}
     />
   )
 }


### PR DESCRIPTION
## Summary
- add optional disabled propagation to EmptyState and its connect wrappers
- extend quick actions to allow disabling onClick buttons
- align dashboard connect buttons and empty states with SDK readiness

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cc32c304fc832f9931870790a1f7ba