### PR TITLE
Add theme provider and theme toggle controls

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,13 +1,18 @@
 import '../globals.css'
 import { Inter } from 'next/font/google'
+import ThemeToggle from '@/components/theme-toggle'
+import Providers from '../providers'
 
 const inter = Inter({ subsets: ['latin'] })
 
 export default function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="pt-br">
+    <html lang="pt-br" suppressHydrationWarning>
       <body className={`${inter.className} min-h-screen flex items-center justify-center`}>
-        {children}
+        <Providers>
+          <ThemeToggle className="fixed top-6 right-6 z-50" />
+          {children}
+        </Providers>
       </body>
     </html>
   )

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,20 @@
 import './globals.css'
 import { Inter } from 'next/font/google'
 import FluidSidebar from '@/components/fluid-sidebar'
+import ThemeToggle from '@/components/theme-toggle'
 import Providers from './providers'
 
 const inter = Inter({ subsets: ['latin'] })
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="pt-br">
+    <html lang="pt-br" suppressHydrationWarning>
       <head>
         <script src="https://connect.pluggy.ai/sdk.js" async></script>
       </head>
       <body className={inter.className}>
         <Providers>
+          <ThemeToggle className="fixed top-6 right-6 z-50" />
           <main className="min-h-screen w-full relative">
             <FluidSidebar />
             <div className="flex flex-col">

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -3,15 +3,18 @@
 import { ClerkProvider } from '@clerk/nextjs'
 import type { ReactNode } from 'react'
 import { ToastProvider } from '@/contexts/toast-context'
+import { ThemeProvider } from '@/contexts/theme-context'
 import { ToastContainer } from '@/components/ui/toast'
 
 export default function Providers({ children }: { children: ReactNode }) {
   return (
     <ClerkProvider>
-      <ToastProvider>
-        {children}
-        <ToastContainer />
-      </ToastProvider>
+      <ThemeProvider>
+        <ToastProvider>
+          {children}
+          <ToastContainer />
+        </ToastProvider>
+      </ThemeProvider>
     </ClerkProvider>
   )
 }

--- a/components/fluid-sidebar.tsx
+++ b/components/fluid-sidebar.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { MenuItem, MenuContainer } from "@/components/ui/fluid-menu"
+import { useTheme } from "@/contexts/theme-context"
 import {
   Menu as MenuIcon,
   X,
@@ -10,9 +11,14 @@ import {
   CreditCard,
   TrendingUp,
   Plug,
+  Moon,
+  Sun,
 } from "lucide-react"
 
 export default function FluidSidebar() {
+  const { theme, toggleTheme } = useTheme()
+  const isDark = theme === 'dark'
+
   const navItems = [
     { href: '/dashboard', label: 'Dashboard', icon: <Home size={20} strokeWidth={1.5} /> },
     { href: '/budget', label: 'Orçamento', icon: <PiggyBank size={20} strokeWidth={1.5} /> },
@@ -55,6 +61,31 @@ export default function FluidSidebar() {
               label={item.label}
             />
           ))}
+          <MenuItem
+            onClick={toggleTheme}
+            index={navItems.length + 1}
+            label={isDark ? 'Ativar tema claro' : 'Ativar tema escuro'}
+            icon={
+              <div className="relative flex h-6 w-6 items-center justify-center">
+                <Sun
+                  strokeWidth={1.5}
+                  className={`h-5 w-5 transition-all duration-300 ${
+                    isDark
+                      ? 'rotate-90 scale-0 opacity-0'
+                      : 'rotate-0 scale-100 opacity-100 text-amber-300 drop-shadow-[0_0_10px_rgba(251,191,36,0.45)]'
+                  }`}
+                />
+                <Moon
+                  strokeWidth={1.5}
+                  className={`absolute h-5 w-5 -translate-x-1/2 -translate-y-1/2 left-1/2 top-1/2 transition-all duration-300 ${
+                    isDark
+                      ? 'rotate-0 scale-100 opacity-100 text-sky-300 drop-shadow-[0_0_10px_rgba(125,211,252,0.45)]'
+                      : '-rotate-90 scale-0 opacity-0'
+                  }`}
+                />
+              </div>
+            }
+          />
         </MenuContainer>
       </div>
     </div>

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useTheme } from '@/contexts/theme-context'
+import { cn } from '@/lib/utils'
+import { Moon, Sun } from 'lucide-react'
+
+interface ThemeToggleProps {
+  className?: string
+}
+
+export default function ThemeToggle({ className }: ThemeToggleProps) {
+  const { theme, toggleTheme } = useTheme()
+  const isDark = theme === 'dark'
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      aria-label={isDark ? 'Ativar tema claro' : 'Ativar tema escuro'}
+      aria-pressed={isDark}
+      className={cn(
+        'group relative inline-flex h-12 w-12 items-center justify-center overflow-hidden rounded-full border border-white/30 bg-white/10 text-slate-900 shadow-[0_8px_32px_rgba(15,23,42,0.15)] backdrop-blur-xl transition-all duration-300 hover:border-white/40 hover:bg-white/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300/80 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent dark:border-white/10 dark:bg-slate-900/60 dark:text-slate-100 dark:hover:bg-slate-900/70 dark:shadow-[0_8px_32px_rgba(15,23,42,0.35)]',
+        className
+      )}
+    >
+      <span className="sr-only">Alternar entre tema claro e escuro</span>
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10 rounded-full bg-emerald-400/20 opacity-0 blur-xl transition-opacity duration-500 group-hover:opacity-75"
+      />
+      <div className="relative flex h-full w-full items-center justify-center">
+        <Sun
+          aria-hidden
+          strokeWidth={1.5}
+          className={cn(
+            'h-5 w-5 transition-all duration-300',
+            isDark
+              ? 'rotate-90 scale-0 opacity-0'
+              : 'rotate-0 scale-100 opacity-100 text-amber-300 drop-shadow-[0_0_12px_rgba(251,191,36,0.45)]'
+          )}
+        />
+        <Moon
+          aria-hidden
+          strokeWidth={1.5}
+          className={cn(
+            'absolute h-5 w-5 -translate-x-1/2 -translate-y-1/2 transition-all duration-300 left-1/2 top-1/2',
+            isDark
+              ? 'rotate-0 scale-100 opacity-100 text-sky-300 drop-shadow-[0_0_12px_rgba(125,211,252,0.45)]'
+              : '-rotate-90 scale-0 opacity-0'
+          )}
+        />
+      </div>
+    </button>
+  )
+}

--- a/contexts/theme-context.tsx
+++ b/contexts/theme-context.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode
+} from 'react'
+
+const THEME_STORAGE_KEY = 'financeito.theme'
+
+type Theme = 'light' | 'dark'
+
+interface ThemeContextValue {
+  theme: Theme
+  toggleTheme: () => void
+  setTheme: (theme: Theme) => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+const getSystemTheme = (): Theme => {
+  if (typeof window === 'undefined') {
+    return 'light'
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+}
+
+const getInitialTheme = (): { theme: Theme; hasUserPreference: boolean } => {
+  if (typeof window === 'undefined') {
+    return { theme: 'light', hasUserPreference: false }
+  }
+
+  const storedTheme = window.localStorage.getItem(THEME_STORAGE_KEY) as Theme | null
+  if (storedTheme === 'light' || storedTheme === 'dark') {
+    return { theme: storedTheme, hasUserPreference: true }
+  }
+
+  return { theme: getSystemTheme(), hasUserPreference: false }
+}
+
+const applyThemeToDocument = (theme: Theme) => {
+  if (typeof document === 'undefined') {
+    return
+  }
+
+  const root = document.documentElement
+  const oppositeTheme: Theme = theme === 'dark' ? 'light' : 'dark'
+
+  root.classList.remove(oppositeTheme)
+  root.classList.add(theme)
+  root.dataset.theme = theme
+  root.style.colorScheme = theme
+}
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setThemeState] = useState<Theme>('light')
+  const [isThemeResolved, setIsThemeResolved] = useState(false)
+  const [hasUserPreference, setHasUserPreference] = useState(false)
+
+  useEffect(() => {
+    const { theme: initialTheme, hasUserPreference } = getInitialTheme()
+
+    setThemeState(initialTheme)
+    setHasUserPreference(hasUserPreference)
+    applyThemeToDocument(initialTheme)
+    setIsThemeResolved(true)
+  }, [])
+
+  useEffect(() => {
+    if (!isThemeResolved) {
+      return
+    }
+
+    applyThemeToDocument(theme)
+
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    if (hasUserPreference) {
+      window.localStorage.setItem(THEME_STORAGE_KEY, theme)
+    } else {
+      window.localStorage.removeItem(THEME_STORAGE_KEY)
+    }
+  }, [theme, isThemeResolved, hasUserPreference])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key !== THEME_STORAGE_KEY) {
+        return
+      }
+
+      if (event.newValue === 'light' || event.newValue === 'dark') {
+        setHasUserPreference(true)
+        setThemeState(event.newValue)
+      }
+
+      if (event.newValue === null) {
+        const systemTheme = getSystemTheme()
+        setHasUserPreference(false)
+        setThemeState(systemTheme)
+      }
+    }
+
+    window.addEventListener('storage', handleStorage)
+
+    return () => {
+      window.removeEventListener('storage', handleStorage)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+    const handleSystemPreferenceChange = (event: MediaQueryListEvent) => {
+      if (!hasUserPreference) {
+        setThemeState(event.matches ? 'dark' : 'light')
+      }
+    }
+
+    mediaQuery.addEventListener('change', handleSystemPreferenceChange)
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleSystemPreferenceChange)
+    }
+  }, [hasUserPreference])
+
+  const setTheme = useCallback((value: Theme) => {
+    setHasUserPreference(true)
+    setThemeState(value)
+  }, [])
+
+  const toggleTheme = useCallback(() => {
+    setHasUserPreference(true)
+    setThemeState(prev => (prev === 'dark' ? 'light' : 'dark'))
+  }, [])
+
+  const value = useMemo(
+    () => ({
+      theme,
+      toggleTheme,
+      setTheme
+    }),
+    [theme, toggleTheme, setTheme]
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext)
+  if (!context) {
+    throw new Error('useTheme deve ser usado dentro de um ThemeProvider')
+  }
+  return context
+}


### PR DESCRIPTION
## Summary
- add a theme context that persists the user preference, syncs the html class list and listens to system changes
- wrap the shared providers with the new ThemeProvider and display the ThemeToggle in both app layouts
- implement a glassmorphism-inspired ThemeToggle component and expose it both globally and inside the fluid sidebar menu

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cc366b6a94832fac31b1dfb9be56d4