### PR TITLE
feat: add installment count to loans

### DIFF
--- a/app/api/loans/[id]/route.ts
+++ b/app/api/loans/[id]/route.ts
@@ -31,6 +31,19 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
       }
     }
 
+    let installmentCountValue: number | null | undefined
+    if (data.installmentCount !== undefined) {
+      if (data.installmentCount === null || `${data.installmentCount}`.trim() === '') {
+        installmentCountValue = null
+      } else {
+        const parsedInstallmentCount = Number(data.installmentCount)
+        if (!Number.isInteger(parsedInstallmentCount) || parsedInstallmentCount <= 0) {
+          return NextResponse.json({ error: 'Campo installmentCount inválido' }, { status: 400 })
+        }
+        installmentCountValue = parsedInstallmentCount
+      }
+    }
+
     // Verify loan belongs to user
     const existingLoan = await prisma.loan.findFirst({
       where: { id, userId }
@@ -48,6 +61,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
         amount: amountNumber,
         interestRate: interestRateNumber,
         dueDate: data.dueDate ? new Date(data.dueDate) : undefined,
+        installmentCount: installmentCountValue,
         paidAt: data.isPaid && !existingLoan.isPaid ? new Date() : data.isPaid === false ? null : undefined
       }
     })
@@ -56,7 +70,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     const formattedLoan = {
       ...loan,
       amount: Number(loan.amount),
-      interestRate: loan.interestRate ? Number(loan.interestRate) : null
+      interestRate: loan.interestRate ? Number(loan.interestRate) : null,
     }
 
     return NextResponse.json(formattedLoan)

--- a/app/api/loans/route.ts
+++ b/app/api/loans/route.ts
@@ -37,7 +37,18 @@ export async function POST(request: NextRequest) {
     }
 
     const data = await request.json()
-    const { title, description, amount, currency, lenderName, lenderContact, type, interestRate, dueDate } = data
+    const {
+      title,
+      description,
+      amount,
+      currency,
+      lenderName,
+      lenderContact,
+      type,
+      interestRate,
+      dueDate,
+      installmentCount,
+    } = data
 
     // Validate required fields
     if (!title || !amount || !lenderName || !type) {
@@ -64,6 +75,15 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    let installmentCountNumber: number | null = null
+    if (installmentCount !== undefined && installmentCount !== null && `${installmentCount}`.trim() !== '') {
+      const parsedInstallmentCount = Number(installmentCount)
+      if (!Number.isInteger(parsedInstallmentCount) || parsedInstallmentCount <= 0) {
+        return NextResponse.json({ error: 'Campo installmentCount inválido' }, { status: 400 })
+      }
+      installmentCountNumber = parsedInstallmentCount
+    }
+
     // Create loan
     const loan = await prisma.loan.create({
       data: {
@@ -76,7 +96,8 @@ export async function POST(request: NextRequest) {
         lenderContact,
         type,
         interestRate: interestRateNumber,
-        dueDate: dueDate ? new Date(dueDate) : null
+        dueDate: dueDate ? new Date(dueDate) : null,
+        installmentCount: installmentCountNumber,
       }
     })
 
@@ -84,7 +105,7 @@ export async function POST(request: NextRequest) {
     const formattedLoan = {
       ...loan,
       amount: Number(loan.amount),
-      interestRate: loan.interestRate ? Number(loan.interestRate) : null
+      interestRate: loan.interestRate ? Number(loan.interestRate) : null,
     }
 
     return NextResponse.json(formattedLoan, { status: 201 })

--- a/app/loans/page.tsx
+++ b/app/loans/page.tsx
@@ -21,6 +21,7 @@ interface Loan {
   dueDate?: string
   isPaid: boolean
   paidAt?: string
+  installmentCount?: number | null
 }
 
 export default function LoansPage() {
@@ -269,7 +270,7 @@ export default function LoansPage() {
                             <span className="text-slate-300">Vencimento:</span>
                             <span className={`font-semibold ${
                               loan.isPaid ? 'text-green-400' :
-                              isOverdue ? 'text-red-400' : 
+                              isOverdue ? 'text-red-400' :
                               'text-slate-300'
                             }`}>
                               {new Date(loan.dueDate).toLocaleDateString()}
@@ -278,10 +279,25 @@ export default function LoansPage() {
                           </div>
                         )}
 
+                        <div className="flex justify-between items-center text-sm">
+                          <span className="text-slate-300">Pagamento:</span>
+                          <span
+                            className={`font-semibold ${
+                              loan.installmentCount && loan.installmentCount > 1
+                                ? 'text-yellow-300'
+                                : 'text-slate-300'
+                            }`}
+                          >
+                            {loan.installmentCount && loan.installmentCount > 0
+                              ? `${loan.installmentCount}x`
+                              : 'À vista'}
+                          </span>
+                        </div>
+
                         <div className="flex items-center justify-between">
                           <span className={`inline-block px-3 py-1 rounded text-xs font-semibold ${
-                            loan.isPaid 
-                              ? 'bg-green-500/20 text-green-300' 
+                            loan.isPaid
+                              ? 'bg-green-500/20 text-green-300'
                               : 'bg-yellow-500/20 text-yellow-300'
                           }`}>
                             {loan.isPaid ? 'Quitado' : 'Pendente'}

--- a/components/forms/loan-form.tsx
+++ b/components/forms/loan-form.tsx
@@ -18,6 +18,7 @@ interface Loan {
   interestRate?: number
   dueDate?: string
   isPaid?: boolean
+  installmentCount?: number | null
 }
 
 interface LoanFormProps {
@@ -38,10 +39,12 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
     type: loan?.type || 'lent',
     interestRate: loan?.interestRate || 0,
     dueDate: loan?.dueDate ? new Date(loan.dueDate).toISOString().split('T')[0] : '',
-    isPaid: loan?.isPaid || false
+    isPaid: loan?.isPaid || false,
+    installmentCount: loan?.installmentCount ?? null
   })
 
   const [submitting, setSubmitting] = useState(false)
+  const installmentOptions = Array.from({ length: 24 }, (_, index) => index + 1)
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -51,7 +54,8 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
       const submitData = {
         ...formData,
         interestRate: formData.interestRate && formData.interestRate > 0 ? formData.interestRate : undefined,
-        dueDate: formData.dueDate || undefined
+        dueDate: formData.dueDate || undefined,
+        installmentCount: formData.installmentCount ? formData.installmentCount : null
       }
       await onSubmit(submitData)
     } catch (error) {
@@ -176,6 +180,30 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
                   <option value="EUR">EUR (€)</option>
                 </select>
               </div>
+            </div>
+
+            {/* Installments */}
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-2">
+                Número de Parcelas
+              </label>
+              <select
+                value={formData.installmentCount ? String(formData.installmentCount) : ''}
+                onChange={(e) =>
+                  setFormData(prev => ({
+                    ...prev,
+                    installmentCount: e.target.value ? Number(e.target.value) : null
+                  }))
+                }
+                className="w-full px-3 py-2 bg-slate-700/50 border border-slate-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-yellow-500"
+              >
+                <option value="">À vista</option>
+                {installmentOptions.map(option => (
+                  <option key={option} value={option}>
+                    {option}x
+                  </option>
+                ))}
+              </select>
             </div>
 
             {/* Lender Info */}

--- a/prisma/migrations/20250918175815_add_installment_count/migration.sql
+++ b/prisma/migrations/20250918175815_add_installment_count/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Loan" ADD COLUMN     "installmentCount" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,6 +136,7 @@ model Loan {
   lenderContact String?  // Contato opcional
   type          String   // "lent" (emprestei para alguém) ou "borrowed" (peguei emprestado)
   interestRate  Decimal? @db.Decimal(5, 2) // Taxa de juros opcional
+  installmentCount Int? // Quantidade de parcelas (null para pagamento à vista)
   dueDate       DateTime?
   isPaid        Boolean  @default(false)
   paidAt        DateTime?


### PR DESCRIPTION
## Summary
- add an optional `installmentCount` column to the loan schema and generate the corresponding migration
- validate and persist installment counts in the loan creation and update API handlers, returning the value to clients
- expose installment selection in the loan form and show the chosen payment mode in the loans page list

## Testing
- npx prisma migrate dev --name add-installment-count
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc46ed4e64832f9c350520472c7992