### PR TITLE
chore: update prisma packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@clerk/nextjs": "^5.4.2",
-        "@prisma/client": "^5.17.0",
+        "@prisma/client": "^5.22.0",
         "@radix-ui/react-avatar": "^1.1.10",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-progress": "^1.1.7",
@@ -22,7 +22,7 @@
         "lucide-react": "^0.544.0",
         "next": "14.2.5",
         "nodemailer": "^6.9.14",
-        "prisma": "^5.17.0",
+        "prisma": "^5.22.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "recharts": "^2.12.7",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^5.4.2",
-    "@prisma/client": "^5.17.0",
+    "@prisma/client": "^5.22.0",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-progress": "^1.1.7",
@@ -27,7 +27,7 @@
     "lucide-react": "^0.544.0",
     "next": "14.2.5",
     "nodemailer": "^6.9.14",
-    "prisma": "^5.17.0",
+    "prisma": "^5.22.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.12.7",


### PR DESCRIPTION
## Summary
- bump `@prisma/client` and `prisma` dependencies to version 5.22.0
- refresh the lockfile to pick up the new Prisma release

## Testing
- `npm install`
- `npx prisma generate`
- `npm run dev` *(fails: requires DATABASE_URL environment variable for `prisma db push`)*
- `npm run build` *(exits with repeated warnings about `chartColors` import; existing issue)*

------
https://chatgpt.com/codex/tasks/task_e_68cc84509534832f9b67be9b015eaa81