### PR TITLE
Sanitize update payloads for finance resources

### DIFF
--- a/__tests__/api-update-sanitization.test.ts
+++ b/__tests__/api-update-sanitization.test.ts
@@ -1,0 +1,293 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authMock = vi.fn()
+const ensureUserMock = vi.fn()
+
+const goalFindFirstMock = vi.fn()
+const goalUpdateMock = vi.fn()
+
+const loanFindFirstMock = vi.fn()
+const loanUpdateMock = vi.fn()
+
+const subscriptionFindFirstMock = vi.fn()
+const subscriptionUpdateMock = vi.fn()
+
+let goalUpdatePayload: any
+let loanUpdatePayload: any
+let subscriptionUpdatePayload: any
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: authMock
+}))
+
+vi.mock('@/lib/ensure-user', () => ({
+  ensureUser: ensureUserMock
+}))
+
+vi.mock('@/lib/db', () => {
+  const prisma = {
+    goal: {
+      findFirst: goalFindFirstMock,
+      update: goalUpdateMock
+    },
+    loan: {
+      findFirst: loanFindFirstMock,
+      update: loanUpdateMock
+    },
+    subscription: {
+      findFirst: subscriptionFindFirstMock,
+      update: subscriptionUpdateMock
+    }
+  }
+
+  return {
+    prisma,
+    default: prisma
+  }
+})
+
+beforeEach(() => {
+  authMock.mockReset()
+  ensureUserMock.mockReset()
+  goalFindFirstMock.mockReset()
+  goalUpdateMock.mockReset()
+  loanFindFirstMock.mockReset()
+  loanUpdateMock.mockReset()
+  subscriptionFindFirstMock.mockReset()
+  subscriptionUpdateMock.mockReset()
+
+  goalUpdatePayload = undefined
+  loanUpdatePayload = undefined
+  subscriptionUpdatePayload = undefined
+
+  authMock.mockReturnValue({ userId: 'user_123' })
+  ensureUserMock.mockResolvedValue(undefined)
+
+  goalFindFirstMock.mockResolvedValue({
+    id: 'goal_1',
+    userId: 'user_123',
+    title: 'Existing Goal',
+    description: 'Existing description',
+    targetAmount: 500,
+    currentAmount: 200,
+    currency: 'BRL',
+    targetDate: new Date('2025-01-01T00:00:00.000Z'),
+    category: 'general',
+    priority: 'medium',
+    isCompleted: false
+  })
+
+  goalUpdateMock.mockImplementation(async ({ data }: any) => {
+    goalUpdatePayload = data
+    return {
+      id: 'goal_1',
+      userId: 'user_123',
+      title: data.title ?? 'Existing Goal',
+      description: data.description ?? 'Existing description',
+      targetAmount: data.targetAmount ?? 500,
+      currentAmount: data.currentAmount ?? 200,
+      currency: data.currency ?? 'BRL',
+      targetDate: data.targetDate ?? new Date('2025-01-01T00:00:00.000Z'),
+      category: data.category ?? 'general',
+      priority: data.priority ?? 'medium',
+      isCompleted: data.isCompleted ?? false,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+  })
+
+  loanFindFirstMock.mockResolvedValue({
+    id: 'loan_1',
+    userId: 'user_123',
+    isPaid: false,
+    paidAt: null
+  })
+
+  loanUpdateMock.mockImplementation(async ({ data }: any) => {
+    loanUpdatePayload = data
+    return {
+      id: 'loan_1',
+      userId: 'user_123',
+      title: data.title ?? 'Existing Loan',
+      description: data.description ?? null,
+      amount: data.amount ?? 1000,
+      currency: data.currency ?? 'BRL',
+      lenderName: data.lenderName ?? 'Existing Lender',
+      lenderContact: data.lenderContact ?? null,
+      type: data.type ?? 'personal',
+      interestRate: data.interestRate ?? null,
+      installmentCount: data.installmentCount ?? null,
+      dueDate: data.dueDate ?? new Date('2025-01-01T00:00:00.000Z'),
+      isPaid: data.isPaid ?? false,
+      paidAt: Object.prototype.hasOwnProperty.call(data, 'paidAt') ? data.paidAt : null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+  })
+
+  subscriptionFindFirstMock.mockResolvedValue({
+    id: 'subscription_1',
+    userId: 'user_123'
+  })
+
+  subscriptionUpdateMock.mockImplementation(async ({ data }: any) => {
+    subscriptionUpdatePayload = data
+    return {
+      id: 'subscription_1',
+      userId: 'user_123',
+      name: data.name ?? 'Existing Subscription',
+      description: data.description ?? null,
+      amount: data.amount ?? 49.9,
+      currency: data.currency ?? 'BRL',
+      billingCycle: data.billingCycle ?? 'monthly',
+      nextBilling: data.nextBilling ?? new Date('2025-01-01T00:00:00.000Z'),
+      category: data.category ?? null,
+      autoRenew: data.autoRenew ?? true,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }
+  })
+})
+
+describe('Goal update sanitization', () => {
+  it('prevents overriding restricted fields while updating goal', async () => {
+    const { PATCH } = await import('@/app/api/goals/[id]/route')
+
+    const response = await PATCH(
+      new Request('http://localhost/api/goals/goal_1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Updated Goal',
+          description: 'Updated description',
+          targetAmount: '750.5',
+          currentAmount: '320.75',
+          currency: 'USD',
+          targetDate: '2026-06-01T00:00:00.000Z',
+          category: 'travel',
+          priority: 'high',
+          isCompleted: true,
+          userId: 'attacker',
+          createdAt: '1999-01-01T00:00:00.000Z'
+        })
+      }) as any,
+      { params: { id: 'goal_1' } }
+    )
+
+    expect(response.status).toBe(200)
+    expect(goalUpdateMock).toHaveBeenCalledTimes(1)
+    expect(goalUpdatePayload).toMatchObject({
+      title: 'Updated Goal',
+      description: 'Updated description',
+      targetAmount: 750.5,
+      currentAmount: 320.75,
+      currency: 'USD',
+      category: 'travel',
+      priority: 'high',
+      isCompleted: true
+    })
+    expect(goalUpdatePayload.targetDate).toBeInstanceOf(Date)
+    expect(goalUpdatePayload).not.toHaveProperty('userId')
+    expect(goalUpdatePayload).not.toHaveProperty('createdAt')
+
+    const body = await response.json()
+    expect(body.targetAmount).toBe(750.5)
+    expect(body.currentAmount).toBe(320.75)
+  })
+})
+
+describe('Loan update sanitization', () => {
+  it('ignores restricted loan fields and computes paidAt internally', async () => {
+    const { PATCH } = await import('@/app/api/loans/[id]/route')
+
+    const response = await PATCH(
+      new Request('http://localhost/api/loans/loan_1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Updated Loan',
+          description: 'Paid ahead of time',
+          amount: '1500.25',
+          currency: 'USD',
+          lenderName: 'Updated Bank',
+          lenderContact: 'bank@example.com',
+          type: 'auto',
+          interestRate: '3.75',
+          installmentCount: '12',
+          dueDate: '2026-02-01T00:00:00.000Z',
+          isPaid: true,
+          paidAt: '2000-01-01T00:00:00.000Z',
+          userId: 'malicious-user'
+        })
+      }) as any,
+      { params: { id: 'loan_1' } }
+    )
+
+    expect(response.status).toBe(200)
+    expect(loanUpdateMock).toHaveBeenCalledTimes(1)
+    expect(loanUpdatePayload).toMatchObject({
+      title: 'Updated Loan',
+      description: 'Paid ahead of time',
+      amount: 1500.25,
+      currency: 'USD',
+      lenderName: 'Updated Bank',
+      lenderContact: 'bank@example.com',
+      type: 'auto',
+      interestRate: 3.75,
+      installmentCount: 12,
+      isPaid: true
+    })
+    expect(loanUpdatePayload.dueDate).toBeInstanceOf(Date)
+    expect(loanUpdatePayload.paidAt).toBeInstanceOf(Date)
+    expect(loanUpdatePayload).not.toHaveProperty('userId')
+    expect(loanUpdatePayload).not.toHaveProperty('paidAt', '2000-01-01T00:00:00.000Z')
+
+    const body = await response.json()
+    expect(body.amount).toBe(1500.25)
+    expect(body.interestRate).toBe(3.75)
+  })
+})
+
+describe('Subscription update sanitization', () => {
+  it('only passes allowed subscription fields to prisma', async () => {
+    const { PATCH } = await import('@/app/api/subscriptions/[id]/route')
+
+    const response = await PATCH(
+      new Request('http://localhost/api/subscriptions/subscription_1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: 'Updated Plan',
+          description: 'Now includes HD streaming',
+          amount: '29.99',
+          currency: 'USD',
+          billingCycle: 'yearly',
+          nextBilling: '2026-07-15T00:00:00.000Z',
+          category: 'entertainment',
+          autoRenew: false,
+          userId: 'attacker',
+          createdAt: '2001-09-09T00:00:00.000Z'
+        })
+      }) as any,
+      { params: { id: 'subscription_1' } }
+    )
+
+    expect(response.status).toBe(200)
+    expect(subscriptionUpdateMock).toHaveBeenCalledTimes(1)
+    expect(subscriptionUpdatePayload).toMatchObject({
+      name: 'Updated Plan',
+      description: 'Now includes HD streaming',
+      amount: 29.99,
+      currency: 'USD',
+      billingCycle: 'yearly',
+      category: 'entertainment',
+      autoRenew: false
+    })
+    expect(subscriptionUpdatePayload.nextBilling).toBeInstanceOf(Date)
+    expect(subscriptionUpdatePayload).not.toHaveProperty('userId')
+    expect(subscriptionUpdatePayload).not.toHaveProperty('createdAt')
+
+    const body = await response.json()
+    expect(body.amount).toBe(29.99)
+  })
+})

--- a/app/api/goals/[id]/route.ts
+++ b/app/api/goals/[id]/route.ts
@@ -40,15 +40,56 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
       return NextResponse.json({ error: 'Meta não encontrada' }, { status: 404 })
     }
 
+    const updateData: Record<string, any> = {}
+
+    if (Object.prototype.hasOwnProperty.call(data, 'title')) {
+      updateData.title = data.title
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'description')) {
+      updateData.description = data.description
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'targetAmount')) {
+      if (data.targetAmount !== undefined) {
+        updateData.targetAmount = targetAmountNumber
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'currentAmount')) {
+      if (data.currentAmount !== undefined) {
+        updateData.currentAmount = currentAmountNumber
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'currency')) {
+      updateData.currency = data.currency
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'targetDate')) {
+      if (data.targetDate) {
+        updateData.targetDate = new Date(data.targetDate)
+      } else if (data.targetDate === null) {
+        updateData.targetDate = null
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'category')) {
+      updateData.category = data.category
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'priority')) {
+      updateData.priority = data.priority
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'isCompleted')) {
+      updateData.isCompleted = data.isCompleted
+    }
+
     // Update goal
     const goal = await prisma.goal.update({
       where: { id },
-      data: {
-        ...data,
-        targetAmount: targetAmountNumber,
-        currentAmount: currentAmountNumber,
-        targetDate: data.targetDate ? new Date(data.targetDate) : undefined
-      }
+      data: updateData
     })
 
     // Convert Decimal to number for JSON serialization

--- a/app/api/loans/[id]/route.ts
+++ b/app/api/loans/[id]/route.ts
@@ -53,17 +53,70 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
       return NextResponse.json({ error: 'Empréstimo não encontrado' }, { status: 404 })
     }
 
+    const updateData: Record<string, any> = {}
+
+    if (Object.prototype.hasOwnProperty.call(data, 'title')) {
+      updateData.title = data.title
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'description')) {
+      updateData.description = data.description
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'amount')) {
+      if (data.amount !== undefined) {
+        updateData.amount = amountNumber
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'currency')) {
+      updateData.currency = data.currency
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'lenderName')) {
+      updateData.lenderName = data.lenderName
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'lenderContact')) {
+      updateData.lenderContact = data.lenderContact
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'type')) {
+      updateData.type = data.type
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'interestRate')) {
+      if (data.interestRate !== undefined) {
+        updateData.interestRate = interestRateNumber
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'installmentCount')) {
+      updateData.installmentCount = installmentCountValue
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'dueDate')) {
+      if (data.dueDate) {
+        updateData.dueDate = new Date(data.dueDate)
+      } else if (data.dueDate === null) {
+        updateData.dueDate = null
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'isPaid')) {
+      updateData.isPaid = data.isPaid
+
+      if (data.isPaid && !existingLoan.isPaid) {
+        updateData.paidAt = new Date()
+      } else if (data.isPaid === false && existingLoan.isPaid) {
+        updateData.paidAt = null
+      }
+    }
+
     // Update loan
     const loan = await prisma.loan.update({
       where: { id },
-      data: {
-        ...data,
-        amount: amountNumber,
-        interestRate: interestRateNumber,
-        dueDate: data.dueDate ? new Date(data.dueDate) : undefined,
-        installmentCount: installmentCountValue,
-        paidAt: data.isPaid && !existingLoan.isPaid ? new Date() : data.isPaid === false ? null : undefined
-      }
+      data: updateData
     })
 
     // Convert Decimal to number for JSON serialization

--- a/app/api/subscriptions/[id]/route.ts
+++ b/app/api/subscriptions/[id]/route.ts
@@ -32,14 +32,50 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
       return NextResponse.json({ error: 'Assinatura não encontrada' }, { status: 404 })
     }
 
+    const updateData: Record<string, any> = {}
+
+    if (Object.prototype.hasOwnProperty.call(data, 'name')) {
+      updateData.name = data.name
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'description')) {
+      updateData.description = data.description
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'amount')) {
+      if (data.amount !== undefined) {
+        updateData.amount = amountNumber
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'currency')) {
+      updateData.currency = data.currency
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'billingCycle')) {
+      updateData.billingCycle = data.billingCycle
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'nextBilling')) {
+      if (data.nextBilling) {
+        updateData.nextBilling = new Date(data.nextBilling)
+      } else if (data.nextBilling === null) {
+        updateData.nextBilling = null
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'category')) {
+      updateData.category = data.category
+    }
+
+    if (Object.prototype.hasOwnProperty.call(data, 'autoRenew')) {
+      updateData.autoRenew = data.autoRenew
+    }
+
     // Update subscription
     const subscription = await prisma.subscription.update({
       where: { id },
-      data: {
-        ...data,
-        amount: amountNumber,
-        nextBilling: data.nextBilling ? new Date(data.nextBilling) : undefined
-      }
+      data: updateData
     })
 
     // Convert Decimal to number for JSON serialization


### PR DESCRIPTION
## Summary
- restrict goal PATCH updates to vetted fields and handle date/number conversions explicitly
- apply the same whitelist strategy to loan and subscription PATCH handlers, including paidAt logic
- add vitest coverage to confirm restricted payload fields like userId are ignored

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc8d106d38832fa2b0629a72bb116d