### PR TITLE
Adjust layout spacing for sidebar clearance

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import './globals.css'
+import Link from 'next/link'
 import { Inter } from 'next/font/google'
 import FluidSidebar from '@/components/fluid-sidebar'
 import FloatingProfileMenu from '@/components/floating-profile-menu'
@@ -16,11 +17,25 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body className={inter.className}>
         <Providers>
-          <main className="min-h-screen w-full relative">
+          <main className="relative min-h-screen w-full">
             <FluidSidebar />
-            <div className="flex flex-col">
-              <div className="flex-1 p-4 max-w-6xl w-full mx-auto">
-                {children}
+            <div className="flex min-h-screen flex-col">
+              <header className="sticky top-0 z-30">
+                <div className="px-4 pt-6 pb-4 pl-24 sm:px-6 sm:pl-28 lg:px-8 lg:pl-32">
+                  <div className="mx-auto flex w-full max-w-6xl items-center justify-between">
+                    <Link
+                      href="/"
+                      className="text-lg font-semibold text-foreground transition-colors hover:text-primary"
+                    >
+                      Financeito
+                    </Link>
+                  </div>
+                </div>
+              </header>
+              <div className="flex-1 px-4 pb-8 pl-24 sm:px-6 sm:pl-28 lg:px-8 lg:pl-32">
+                <div className="mx-auto w-full max-w-6xl">
+                  {children}
+                </div>
               </div>
             </div>
           </main>


### PR DESCRIPTION
## Summary
- add a left-offset brand header bar in the root layout so the Financeito link clears the floating sidebar trigger on all breakpoints
- mirror the new horizontal spacing on the main content container to keep page bodies aligned with the header padding

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc9c87d3ac832fb847a30b71b9fc43