### PR TITLE
Centralize navigation configuration

### DIFF
--- a/components/fluid-sidebar.tsx
+++ b/components/fluid-sidebar.tsx
@@ -2,31 +2,12 @@
 
 import { MenuItem, MenuContainer } from "@/components/ui/fluid-menu"
 import { useTheme } from "@/contexts/theme-context"
-import {
-  Menu as MenuIcon,
-  X,
-  Home,
-  PiggyBank,
-  Target,
-  CreditCard,
-  TrendingUp,
-  Plug,
-  Moon,
-  Sun,
-} from "lucide-react"
+import { navigationItems } from "@/config/navigation"
+import { Menu as MenuIcon, X, Moon, Sun } from "lucide-react"
 
 export default function FluidSidebar() {
   const { theme, toggleTheme } = useTheme()
   const isDark = theme === 'dark'
-
-  const navItems = [
-    { href: '/dashboard', label: 'Dashboard', icon: <Home size={20} strokeWidth={1.5} /> },
-    { href: '/budget', label: 'Orçamento', icon: <PiggyBank size={20} strokeWidth={1.5} /> },
-    { href: '/goals', label: 'Metas', icon: <Target size={20} strokeWidth={1.5} /> },
-    { href: '/subscriptions', label: 'Assinaturas', icon: <CreditCard size={20} strokeWidth={1.5} /> },
-    { href: '/integrations', label: 'Integrações', icon: <Plug size={20} strokeWidth={1.5} /> },
-    { href: '/loans', label: 'Empréstimos', icon: <TrendingUp size={20} strokeWidth={1.5} /> },
-  ]
 
   return (
     <div className="fixed top-8 left-8 z-50">
@@ -52,18 +33,24 @@ export default function FluidSidebar() {
           />
           
           {/* Itens de navegação */}
-          {navItems.map((item, index) => (
-            <MenuItem
-              key={item.href}
-              href={item.href}
-              icon={item.icon}
-              index={index + 1}
-              label={item.label}
-            />
-          ))}
+          {navigationItems.map((item, index) => {
+            const Icon = item.icon
+
+            return (
+              <MenuItem
+                key={item.href}
+                href={item.href}
+                icon={
+                  Icon ? <Icon size={20} strokeWidth={1.5} /> : undefined
+                }
+                index={index + 1}
+                label={item.label}
+              />
+            )
+          })}
           <MenuItem
             onClick={toggleTheme}
-            index={navItems.length + 1}
+            index={navigationItems.length + 1}
             label={isDark ? 'Ativar tema claro' : 'Ativar tema escuro'}
             icon={
               <div className="relative flex h-6 w-6 items-center justify-center">

--- a/components/quick-access.tsx
+++ b/components/quick-access.tsx
@@ -2,12 +2,7 @@
 
 import Link from 'next/link'
 import { LiquidCard } from '@/components/ui/liquid-card'
-
-export interface QuickAccessItem {
-  title: string
-  description: string
-  href: string
-}
+import type { QuickAccessItem } from '@/config/navigation'
 
 interface QuickAccessProps {
   items: QuickAccessItem[]
@@ -29,3 +24,5 @@ export function QuickAccess({ items }: QuickAccessProps) {
 }
 
 export default QuickAccess
+
+export type { QuickAccessItem }

--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -2,17 +2,11 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+import { navigationItems } from '@/config/navigation'
 
 export default function Sidebar() {
   const pathname = usePathname()
-
-  const navItems = [
-    { href: '/dashboard', label: 'Dashboard' },
-    { href: '/budget', label: 'Orçamento' },
-    { href: '/goals', label: 'Metas' },
-    { href: '/subscriptions', label: 'Assinaturas' },
-    { href: '/loans', label: 'Empréstimos' },
-  ]
+  const navItems = navigationItems.filter((item) => item.showInSidebar !== false)
 
   return (
     <aside className="sticky top-0 h-screen w-64 bg-sidebar text-sidebar-foreground border-r border-sidebar-border p-4">

--- a/config/navigation.ts
+++ b/config/navigation.ts
@@ -1,0 +1,102 @@
+import { CreditCard, Home, PiggyBank, Plug, Target, TrendingUp } from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+export interface QuickAccessItem {
+  title: string
+  description: string
+  href: string
+}
+
+export interface NavigationItem {
+  href: string
+  label: string
+  icon?: LucideIcon
+  showInSidebar?: boolean
+  quickAccessItems?: QuickAccessItem[]
+}
+
+export const navigationItems: NavigationItem[] = [
+  {
+    href: '/dashboard',
+    label: 'Dashboard',
+    icon: Home,
+    quickAccessItems: [
+      {
+        title: 'Contas',
+        description: 'Resumo das suas contas conectadas',
+        href: '/dashboard#accounts',
+      },
+      {
+        title: 'Transações',
+        description: 'Histórico de movimentações',
+        href: '/dashboard#transactions',
+      },
+      {
+        title: 'Evolução de Saldos',
+        description: 'Gráficos dos saldos ao longo do tempo',
+        href: '/dashboard#balance-evolution',
+      },
+    ],
+  },
+  {
+    href: '/budget',
+    label: 'Orçamento',
+    icon: PiggyBank,
+    quickAccessItems: [
+      {
+        title: 'Orçamentos',
+        description: 'Planeje seus gastos',
+        href: '/budget',
+      },
+    ],
+  },
+  {
+    href: '/goals',
+    label: 'Metas',
+    icon: Target,
+    quickAccessItems: [
+      {
+        title: 'Metas',
+        description: 'Acompanhe seus objetivos',
+        href: '/goals',
+      },
+    ],
+  },
+  {
+    href: '/subscriptions',
+    label: 'Assinaturas',
+    icon: CreditCard,
+    quickAccessItems: [
+      {
+        title: 'Assinaturas',
+        description: 'Controle suas assinaturas',
+        href: '/subscriptions',
+      },
+    ],
+  },
+  {
+    href: '/integrations',
+    label: 'Integrações',
+    icon: Plug,
+    showInSidebar: false,
+    quickAccessItems: [
+      {
+        title: 'Integrações',
+        description: 'Gerencie conexões com bancos e serviços',
+        href: '/integrations',
+      },
+    ],
+  },
+  {
+    href: '/loans',
+    label: 'Empréstimos',
+    icon: TrendingUp,
+    quickAccessItems: [
+      {
+        title: 'Empréstimos',
+        description: 'Gerencie seus empréstimos',
+        href: '/loans',
+      },
+    ],
+  },
+]

--- a/hooks/use-dashboard-data.ts
+++ b/hooks/use-dashboard-data.ts
@@ -16,7 +16,8 @@ import type {
 } from '@/components/forms/transaction-form'
 import type { ManualAccountFormData } from '@/components/forms/manual-account-form'
 import type { QuickAction } from '@/components/quick-actions'
-import type { QuickAccessItem } from '@/components/quick-access'
+import { navigationItems } from '@/config/navigation'
+import type { QuickAccessItem } from '@/config/navigation'
 import type { TransactionCalendarDay } from '@/components/transactions/transaction-calendar'
 import {
   formatDateToISODate,
@@ -463,36 +464,13 @@ export const useDashboardData = () => {
   )
 
   const quickAccessItems = useMemo<QuickAccessItem[]>(
-    () => [
-      {
-        title: 'Contas',
-        description: 'Resumo das suas contas conectadas',
-        href: '/dashboard#accounts',
-      },
-      {
-        title: 'Transações',
-        description: 'Histórico de movimentações',
-        href: '/dashboard#transactions',
-      },
-      {
-        title: 'Evolução de Saldos',
-        description: 'Gráficos dos saldos ao longo do tempo',
-        href: '/dashboard#balance-evolution',
-      },
-      { title: 'Orçamentos', description: 'Planeje seus gastos', href: '/budget' },
-      { title: 'Metas', description: 'Acompanhe seus objetivos', href: '/goals' },
-      {
-        title: 'Assinaturas',
-        description: 'Controle suas assinaturas',
-        href: '/subscriptions',
-      },
-      {
-        title: 'Integrações',
-        description: 'Gerencie conexões com bancos e serviços',
-        href: '/integrations',
-      },
-      { title: 'Empréstimos', description: 'Gerencie seus empréstimos', href: '/loans' },
-    ],
+    () =>
+      navigationItems.flatMap((item) => item.quickAccessItems ?? [])
+        .filter((shortcut, index, array) => {
+          const firstIndex = array.findIndex((candidate) => candidate.href === shortcut.href)
+
+          return firstIndex === index
+        }),
     [],
   )
 


### PR DESCRIPTION
## Summary
- add a typed navigation configuration with shared quick access metadata
- update sidebar components to map their links from the centralized config
- derive dashboard quick access items from the shared navigation data

## Testing
- npx vitest run --reporter=basic

------
https://chatgpt.com/codex/tasks/task_e_68ccad12eb98832f8e018dfbdfd1ff76