### PR TITLE
Handle nullable loan fields

### DIFF
--- a/__tests__/api-update-sanitization.test.ts
+++ b/__tests__/api-update-sanitization.test.ts
@@ -336,6 +336,29 @@ describe('Loan update sanitization', () => {
     expect(typeof body.dueDate).toBe('string')
     expect(typeof body.paidAt).toBe('string')
   })
+
+  it('clears nullable loan fields when provided null values', async () => {
+    const { PATCH } = await import('@/app/api/loans/[id]/route')
+
+    const response = await PATCH(
+      new Request('http://localhost/api/loans/loan_1', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          interestRate: null,
+          dueDate: null
+        })
+      }) as any,
+      { params: { id: 'loan_1' } }
+    )
+
+    expect(response.status).toBe(200)
+    expect(loanUpdateMock).toHaveBeenCalledTimes(1)
+    expect(loanUpdatePayload).toMatchObject({
+      interestRate: null,
+      dueDate: null
+    })
+  })
 })
 
 describe('Subscription update sanitization', () => {

--- a/app/api/loans/[id]/route.ts
+++ b/app/api/loans/[id]/route.ts
@@ -24,11 +24,16 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
       }
     }
 
-    let interestRateNumber: number | undefined
-    if (data.interestRate !== undefined) {
-      interestRateNumber = Number(data.interestRate)
-      if (Number.isNaN(interestRateNumber)) {
-        return NextResponse.json({ error: 'Campo interestRate inválido' }, { status: 400 })
+    let interestRateValue: number | null | undefined
+    if (Object.prototype.hasOwnProperty.call(data, 'interestRate')) {
+      if (data.interestRate === null || `${data.interestRate}`.trim() === '') {
+        interestRateValue = null
+      } else {
+        const parsedInterestRate = Number(data.interestRate)
+        if (Number.isNaN(parsedInterestRate)) {
+          return NextResponse.json({ error: 'Campo interestRate inválido' }, { status: 400 })
+        }
+        interestRateValue = parsedInterestRate
       }
     }
 
@@ -87,9 +92,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     }
 
     if (Object.prototype.hasOwnProperty.call(data, 'interestRate')) {
-      if (data.interestRate !== undefined) {
-        updateData.interestRate = interestRateNumber
-      }
+      updateData.interestRate = interestRateValue
     }
 
     if (Object.prototype.hasOwnProperty.call(data, 'installmentCount')) {
@@ -97,10 +100,10 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     }
 
     if (Object.prototype.hasOwnProperty.call(data, 'dueDate')) {
-      if (data.dueDate) {
-        updateData.dueDate = new Date(data.dueDate)
-      } else if (data.dueDate === null) {
+      if (data.dueDate === null || (typeof data.dueDate === 'string' && data.dueDate.trim() === '')) {
         updateData.dueDate = null
+      } else if (data.dueDate) {
+        updateData.dueDate = new Date(data.dueDate)
       }
     }
 

--- a/app/loans/page.tsx
+++ b/app/loans/page.tsx
@@ -17,10 +17,10 @@ interface Loan {
   lenderName: string
   lenderContact?: string
   type: string // 'lent' ou 'borrowed'
-  interestRate?: number
-  dueDate?: string
+  interestRate?: number | null
+  dueDate?: string | null
   isPaid: boolean
-  paidAt?: string
+  paidAt?: string | null
   installmentCount?: number | null
 }
 

--- a/components/forms/loan-form.tsx
+++ b/components/forms/loan-form.tsx
@@ -15,8 +15,8 @@ interface Loan {
   lenderName: string
   lenderContact?: string
   type: string
-  interestRate?: number
-  dueDate?: string
+  interestRate?: number | null
+  dueDate?: string | null
   isPaid?: boolean
   installmentCount?: number | null
 }
@@ -53,8 +53,9 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
     try {
       const submitData = {
         ...formData,
-        interestRate: formData.interestRate && formData.interestRate > 0 ? formData.interestRate : undefined,
-        dueDate: formData.dueDate || undefined,
+        interestRate:
+          formData.interestRate && formData.interestRate > 0 ? formData.interestRate : null,
+        dueDate: formData.dueDate ? formData.dueDate : null,
         installmentCount: formData.installmentCount ? formData.installmentCount : null
       }
       await onSubmit(submitData)


### PR DESCRIPTION
## Summary
- send `null` for cleared interest and due date fields from the loan form
- treat `null`/empty values for `interestRate` and `dueDate` when patching loans
- add a regression test ensuring the API clears these fields when `null` is provided

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ce29c71dcc832f8612587d84f3f1f6