### PR TITLE
Restore chart colors export and align form typings

### DIFF
--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -5,7 +5,7 @@ import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
 import { ConfirmDeleteModal } from '@/components/ui/confirm-delete-modal'
-import { GoalForm } from '@/components/forms/goal-form'
+import { GoalForm, type GoalFormData } from '@/components/forms/goal-form'
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, BarChart, Bar, XAxis, YAxis } from 'recharts'
 import { ResourceMessages, useResourceCrud } from '@/hooks/useResourceCrud'
 
@@ -65,16 +65,16 @@ function GoalsPageContent() {
     createItem: createGoal,
     updateItem: updateGoal,
     deleteItem: deleteGoal
-  } = useResourceCrud<Goal, Goal, Goal>({
+  } = useResourceCrud<Goal, GoalFormData, GoalFormData>({
     baseUrl: '/api/goals',
     messages: goalMessages
   })
 
-  const handleCreateGoal = async (goalData: Goal) => {
+  const handleCreateGoal = async (goalData: GoalFormData) => {
     await createGoal(goalData)
   }
 
-  const handleEditGoal = async (goalData: Goal) => {
+  const handleEditGoal = async (goalData: GoalFormData) => {
     if (!editingGoal?.id) return
     await updateGoal(editingGoal.id, goalData)
   }

--- a/app/loans/page.tsx
+++ b/app/loans/page.tsx
@@ -4,7 +4,7 @@ import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
 import { ConfirmDeleteModal } from '@/components/ui/confirm-delete-modal'
-import { LoanForm } from '@/components/forms/loan-form'
+import { LoanForm, type LoanFormData } from '@/components/forms/loan-form'
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, PieChart, Pie, Cell } from 'recharts'
 import { ResourceMessages, useResourceCrud } from '@/hooks/useResourceCrud'
 
@@ -67,16 +67,16 @@ export default function LoansPage() {
     createItem: createLoan,
     updateItem: updateLoan,
     deleteItem: deleteLoan
-  } = useResourceCrud<Loan, Loan, Loan>({
+  } = useResourceCrud<Loan, LoanFormData, LoanFormData>({
     baseUrl: '/api/loans',
     messages: loanMessages
   })
 
-  const handleCreateLoan = async (loanData: Loan) => {
+  const handleCreateLoan = async (loanData: LoanFormData) => {
     await createLoan(loanData)
   }
 
-  const handleEditLoan = async (loanData: Loan) => {
+  const handleEditLoan = async (loanData: LoanFormData) => {
     if (!editingLoan?.id) return
     await updateLoan(editingLoan.id, loanData)
   }

--- a/app/subscriptions/page.tsx
+++ b/app/subscriptions/page.tsx
@@ -4,7 +4,7 @@ import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
 import { ConfirmDeleteModal } from '@/components/ui/confirm-delete-modal'
-import { SubscriptionForm } from '@/components/forms/subscription-form'
+import { SubscriptionForm, type SubscriptionFormData } from '@/components/forms/subscription-form'
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Tooltip, PieChart, Pie, Cell } from 'recharts'
 import { ResourceMessages, useResourceCrud } from '@/hooks/useResourceCrud'
 
@@ -64,16 +64,16 @@ export default function SubscriptionsPage() {
     createItem: createSubscription,
     updateItem: updateSubscription,
     deleteItem: deleteSubscription
-  } = useResourceCrud<Subscription, Subscription, Subscription>({
+  } = useResourceCrud<Subscription, SubscriptionFormData, SubscriptionFormData>({
     baseUrl: '/api/subscriptions',
     messages: subscriptionMessages
   })
 
-  const handleCreateSubscription = async (subscriptionData: Subscription) => {
+  const handleCreateSubscription = async (subscriptionData: SubscriptionFormData) => {
     await createSubscription(subscriptionData)
   }
 
-  const handleEditSubscription = async (subscriptionData: Subscription) => {
+  const handleEditSubscription = async (subscriptionData: SubscriptionFormData) => {
     if (!editingSubscription?.id) return
     await updateSubscription(editingSubscription.id, subscriptionData)
   }

--- a/components/forms/goal-form.tsx
+++ b/components/forms/goal-form.tsx
@@ -6,7 +6,7 @@ import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
 import { LiquidInput } from '@/components/ui/liquid-input'
 
-interface Goal {
+export interface GoalFormData {
   id?: string
   title: string
   description?: string
@@ -16,17 +16,18 @@ interface Goal {
   targetDate: string
   category?: string
   priority: string
+  isCompleted?: boolean
 }
 
 interface GoalFormProps {
-  goal?: Goal
-  onSubmit: (goal: Goal) => Promise<void>
+  goal?: GoalFormData
+  onSubmit: (goal: GoalFormData) => Promise<void>
   onCancel: () => void
   loading?: boolean
 }
 
 export function GoalForm({ goal, onSubmit, onCancel, loading }: GoalFormProps) {
-  const [formData, setFormData] = useState<Goal>({
+  const [formData, setFormData] = useState<GoalFormData>({
     title: goal?.title || '',
     description: goal?.description || '',
     targetAmount: goal?.targetAmount || 0,
@@ -34,7 +35,8 @@ export function GoalForm({ goal, onSubmit, onCancel, loading }: GoalFormProps) {
     currency: goal?.currency || 'BRL',
     targetDate: goal?.targetDate ? new Date(goal.targetDate).toISOString().split('T')[0] : '',
     category: goal?.category || '',
-    priority: goal?.priority || 'medium'
+    priority: goal?.priority || 'medium',
+    isCompleted: goal?.isCompleted || false
   })
 
   const [submitting, setSubmitting] = useState(false)

--- a/components/forms/loan-form.tsx
+++ b/components/forms/loan-form.tsx
@@ -6,7 +6,7 @@ import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
 import { LiquidInput } from '@/components/ui/liquid-input'
 
-interface Loan {
+export interface LoanFormData {
   id?: string
   title: string
   description?: string
@@ -22,14 +22,14 @@ interface Loan {
 }
 
 interface LoanFormProps {
-  loan?: Loan
-  onSubmit: (loan: Loan) => Promise<void>
+  loan?: LoanFormData
+  onSubmit: (loan: LoanFormData) => Promise<void>
   onCancel: () => void
   loading?: boolean
 }
 
 export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
-  const [formData, setFormData] = useState<Loan>({
+  const [formData, setFormData] = useState<LoanFormData>({
     title: loan?.title || '',
     description: loan?.description || '',
     amount: loan?.amount || 0,
@@ -246,7 +246,7 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
                 <LiquidInput
                   type="number"
                   step="0.01"
-                  value={formData.interestRate}
+                  value={formData.interestRate ?? ''}
                   onChange={(e) => setFormData(prev => ({ ...prev, interestRate: parseFloat(e.target.value) || 0 }))}
                   placeholder="0,00"
                   className="focus:ring-2 focus:ring-yellow-500"
@@ -259,7 +259,7 @@ export function LoanForm({ loan, onSubmit, onCancel, loading }: LoanFormProps) {
                 </label>
                 <LiquidInput
                   type="date"
-                  value={formData.dueDate}
+                  value={formData.dueDate ?? ''}
                   onChange={(e) => setFormData(prev => ({ ...prev, dueDate: e.target.value }))}
                   className="focus:ring-2 focus:ring-yellow-500"
                 />

--- a/components/forms/subscription-form.tsx
+++ b/components/forms/subscription-form.tsx
@@ -6,7 +6,7 @@ import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
 import { LiquidInput } from '@/components/ui/liquid-input'
 
-interface Subscription {
+export interface SubscriptionFormData {
   id?: string
   name: string
   description?: string
@@ -16,17 +16,18 @@ interface Subscription {
   nextBilling: string
   category?: string
   autoRenew: boolean
+  isActive?: boolean
 }
 
 interface SubscriptionFormProps {
-  subscription?: Subscription
-  onSubmit: (subscription: Subscription) => Promise<void>
+  subscription?: SubscriptionFormData
+  onSubmit: (subscription: SubscriptionFormData) => Promise<void>
   onCancel: () => void
   loading?: boolean
 }
 
 export function SubscriptionForm({ subscription, onSubmit, onCancel, loading }: SubscriptionFormProps) {
-  const [formData, setFormData] = useState<Subscription>({
+  const [formData, setFormData] = useState<SubscriptionFormData>({
     name: subscription?.name || '',
     description: subscription?.description || '',
     amount: subscription?.amount || 0,
@@ -34,7 +35,8 @@ export function SubscriptionForm({ subscription, onSubmit, onCancel, loading }: 
     billingCycle: subscription?.billingCycle || 'monthly',
     nextBilling: subscription?.nextBilling ? new Date(subscription.nextBilling).toISOString().split('T')[0] : '',
     category: subscription?.category || '',
-    autoRenew: subscription?.autoRenew ?? true
+    autoRenew: subscription?.autoRenew ?? true,
+    isActive: subscription?.isActive ?? true
   })
 
   const [submitting, setSubmitting] = useState(false)

--- a/lib/theme.ts
+++ b/lib/theme.ts
@@ -1,3 +1,12 @@
+export const chartColors = [
+  'hsl(var(--color-dashboard))',
+  'hsl(var(--color-accounts))',
+  'hsl(var(--color-transactions))',
+  'hsl(var(--color-investments))',
+  'hsl(var(--color-goals))',
+  'hsl(var(--destructive))',
+]
+
 export const THEME_STORAGE_KEY = 'financeito.theme' as const
 
 export type Theme = 'light' | 'dark'


### PR DESCRIPTION
## Summary
- restore the `chartColors` array export in `lib/theme` using the existing dashboard palette
- adjust goal, loan, and subscription forms to export shared form data types and ensure optional fields default correctly
- update the respective pages to consume the new form types with `useResourceCrud`

## Testing
- `CI=1 npm run build` *(fails: build requires valid encryption credentials and Clerk publishable key in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce37ead310832fbff834e9167744fc