### PR TITLE
Wrap loans and subscriptions pages with Suspense

### DIFF
--- a/app/loans/page.tsx
+++ b/app/loans/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Suspense } from 'react'
 import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
@@ -51,7 +52,7 @@ const loanMessages: ResourceMessages = {
   }
 }
 
-export default function LoansPage() {
+function LoansPageContent() {
   const {
     items: loans,
     loading,
@@ -414,5 +415,22 @@ export default function LoansPage() {
         onConfirm={() => deletingLoan && handleDeleteLoan(deletingLoan)}
       />
     </div>
+  )
+}
+
+export default function LoansPage() {
+  return (
+    <Suspense
+      fallback={(
+        <div className="space-y-6">
+          <div className="text-center py-12">
+            <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-yellow-400"></div>
+            <p className="mt-2 text-slate-400">Carregando empréstimos...</p>
+          </div>
+        </div>
+      )}
+    >
+      <LoansPageContent />
+    </Suspense>
   )
 }

--- a/app/subscriptions/page.tsx
+++ b/app/subscriptions/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Suspense } from 'react'
 import { motion } from 'framer-motion'
 import { LiquidCard } from '@/components/ui/liquid-card'
 import { LiquidButton } from '@/components/ui/liquid-button'
@@ -48,7 +49,7 @@ const subscriptionMessages: ResourceMessages = {
   }
 }
 
-export default function SubscriptionsPage() {
+function SubscriptionsPageContent() {
   const {
     items: subscriptions,
     loading,
@@ -401,5 +402,22 @@ export default function SubscriptionsPage() {
         onConfirm={() => deletingSubscription && handleDeleteSubscription(deletingSubscription)}
       />
     </div>
+  )
+}
+
+export default function SubscriptionsPage() {
+  return (
+    <Suspense
+      fallback={(
+        <div className="space-y-6">
+          <div className="text-center py-12">
+            <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-purple-400"></div>
+            <p className="mt-2 text-slate-400">Carregando assinaturas...</p>
+          </div>
+        </div>
+      )}
+    >
+      <SubscriptionsPageContent />
+    </Suspense>
   )
 }


### PR DESCRIPTION
## Summary
- extract the loans page content into a dedicated client component and wrap it in Suspense with a loading fallback
- mirror the Suspense pattern on the subscriptions page with its own loading spinner fallback

## Testing
- npm run build *(fails: missing Clerk publishableKey environment variable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce45dc8fb4832f91fe721109cb4876