### PR TITLE
Normalize Pluggy connect token parsing

### DIFF
--- a/lib/pluggy-connect.ts
+++ b/lib/pluggy-connect.ts
@@ -39,7 +39,8 @@ export function createHandleConnect({ toast, onAfterSync }: CreateHandleConnectO
       }
 
       const json = await response.json()
-      const connectToken = json.connectToken || json.linkToken
+      const connectToken =
+        json.connectToken ?? json.connect_token ?? json.linkToken ?? json.link_token
 
       if (!connectToken) {
         toast.error(

--- a/lib/pluggy.ts
+++ b/lib/pluggy.ts
@@ -43,14 +43,20 @@ async function authHeaders() {
   return { 'X-API-KEY': apiKey }
 }
 
+function normalizeConnectTokenResponse<T extends Record<string, any>>(data: T) {
+  const connectToken =
+    data.connectToken ?? data.connect_token ?? data.linkToken ?? data.link_token ?? data.token
+  return { ...data, connectToken }
+}
+
 export async function createConnectToken(payload?: Record<string, any>) {
   const headers = await authHeaders()
   try {
     const { data } = await axios.post(`${BASE_URL}/connect_token`, payload || {}, { headers })
-    return data
+    return normalizeConnectTokenResponse(data)
   } catch {
     const { data } = await axios.post(`${BASE_URL}/link/token`, payload || {}, { headers })
-    return data
+    return normalizeConnectTokenResponse(data)
   }
 }
 


### PR DESCRIPTION
## Summary
- normalize connect token parsing in the Pluggy Connect handler to accept multiple response keys
- normalize the Pluggy API connect token response so the API route always returns a `connectToken` field

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce5481c4f8832f8f6acd0677400d33