### PR TITLE
Allow auth logging on LAN hostnames

### DIFF
--- a/components/auth/custom-signin.tsx
+++ b/components/auth/custom-signin.tsx
@@ -10,6 +10,14 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
+const allowedLogHostnames = (process.env.NEXT_PUBLIC_ALLOWED_LOG_HOSTNAMES ?? 'localhost,192.168.0.18')
+  .split(',')
+  .map((hostname) => hostname.trim())
+  .filter(Boolean);
+
+const isAllowedLogHostname = () =>
+  typeof window !== 'undefined' && allowedLogHostnames.includes(window.location.hostname);
+
 interface CustomSignInProps {
   redirectUrl?: string;
 }
@@ -57,7 +65,7 @@ export default function CustomSignIn({ redirectUrl = "/dashboard" }: CustomSignI
       }
       
       // Log detailed error for debugging (only in development)
-      if (typeof window !== 'undefined' && window.location.hostname === 'localhost') {
+      if (isAllowedLogHostname()) {
         console.error('Login error:', err.errors?.[0]);
       }
     }

--- a/components/auth/custom-signup.tsx
+++ b/components/auth/custom-signup.tsx
@@ -10,6 +10,14 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
+const allowedLogHostnames = (process.env.NEXT_PUBLIC_ALLOWED_LOG_HOSTNAMES ?? 'localhost,192.168.0.18')
+  .split(',')
+  .map((hostname) => hostname.trim())
+  .filter(Boolean);
+
+const isAllowedLogHostname = () =>
+  typeof window !== 'undefined' && allowedLogHostnames.includes(window.location.hostname);
+
 interface CustomSignUpProps {
   redirectUrl?: string;
 }
@@ -58,7 +66,7 @@ export default function CustomSignUp({ redirectUrl = "/dashboard" }: CustomSignU
       }
       
       // Log detailed error for debugging (only in development)
-      if (typeof window !== 'undefined' && window.location.hostname === 'localhost') {
+      if (isAllowedLogHostname()) {
         console.error('Signup error:', err.errors?.[0]);
       }
     }
@@ -94,7 +102,7 @@ export default function CustomSignUp({ redirectUrl = "/dashboard" }: CustomSignU
       }
       
       // Log detailed error for debugging (only in development)
-      if (typeof window !== 'undefined' && window.location.hostname === 'localhost') {
+      if (isAllowedLogHostname()) {
         console.error('Verification error:', err.errors?.[0]);
       }
     }

--- a/components/auth/mfa-verification.tsx
+++ b/components/auth/mfa-verification.tsx
@@ -10,6 +10,14 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
+const allowedLogHostnames = (process.env.NEXT_PUBLIC_ALLOWED_LOG_HOSTNAMES ?? 'localhost,192.168.0.18')
+  .split(',')
+  .map((hostname) => hostname.trim())
+  .filter(Boolean);
+
+const isAllowedLogHostname = () =>
+  typeof window !== 'undefined' && allowedLogHostnames.includes(window.location.hostname);
+
 interface MFAVerificationProps {
   redirectUrl?: string;
 }
@@ -53,7 +61,7 @@ export default function MFAVerification({ redirectUrl = "/dashboard" }: MFAVerif
       }
       
       // Log detailed error for debugging (only in development)
-      if (typeof window !== 'undefined' && window.location.hostname === 'localhost') {
+      if (isAllowedLogHostname()) {
         console.error('MFA verification error:', err.errors?.[0]);
       }
     }


### PR DESCRIPTION
## Summary
- allow configuring which hostnames can trigger client-side auth logging via an environment variable with sensible defaults
- apply the shared hostname check to the sign-in, sign-up, and MFA flows to support debugging from localhost or 192.168.0.18

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce83c23d44832fab252366e4701b7b