### PR TITLE
Update subscription upcoming payment fields

### DIFF
--- a/hooks/use-dashboard-data.ts
+++ b/hooks/use-dashboard-data.ts
@@ -551,14 +551,14 @@ export const useDashboardData = () => {
       ...subscriptions
         .filter(
           (subscription) =>
-            subscription.nextBillingDate &&
-            isUpcoming(subscription.nextBillingDate, 7),
+            subscription.nextBilling &&
+            isUpcoming(subscription.nextBilling, 7),
         )
         .map((subscription) => ({
           type: 'Assinatura',
           name: subscription.name,
-          date: subscription.nextBillingDate,
-          amount: subscription.price,
+          date: subscription.nextBilling,
+          amount: subscription.amount,
         })),
       ...loans
         .filter(


### PR DESCRIPTION
## Summary
- update dashboard upcoming subscription data to use the latest billing date and amount fields
- ensure the upcoming filter uses the corrected next billing date property

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cea34a1a84832f952f39591fc59548