### PR TITLE
Ensure upcoming payments use loan titles

### DIFF
--- a/__tests__/upcoming-payments.test.ts
+++ b/__tests__/upcoming-payments.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildUpcomingPayments } from '@/hooks/use-dashboard-data'
+
+const futureDate = (days: number) =>
+  new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString()
+
+describe('buildUpcomingPayments', () => {
+  it('uses the loan title when no description is provided', () => {
+    const payments = buildUpcomingPayments([], [
+      {
+        title: 'Car Loan',
+        description: undefined,
+        amount: 500,
+        dueDate: futureDate(2),
+        isPaid: false,
+      },
+    ])
+
+    expect(payments).toHaveLength(1)
+    expect(payments[0]).toMatchObject({
+      type: 'Empréstimo',
+      name: 'Car Loan',
+    })
+  })
+
+  it('falls back to the loan description when the title is not available', () => {
+    const payments = buildUpcomingPayments([], [
+      {
+        title: '   ',
+        description: 'Emergency funds loan',
+        amount: 300,
+        dueDate: futureDate(3),
+        isPaid: false,
+      },
+    ])
+
+    expect(payments).toHaveLength(1)
+    expect(payments[0]).toMatchObject({
+      type: 'Empréstimo',
+      name: 'Emergency funds loan',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- prefer loan titles when composing upcoming payments and only fall back to descriptions when needed
- extract a reusable helper for building the upcoming payments list with a safe loan label
- add regression tests covering the loan title and description fallback behaviour

## Testing
- npx vitest run __tests__/api-update-sanitization.test.ts
- npx vitest run __tests__/date-validation.test.ts
- npx vitest run __tests__/ensure-user-route.test.ts
- npx vitest run __tests__/user-dropdown-routes.test.ts
- npx vitest run __tests__/upcoming-payments.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cea3ac3f84832fa2169cfd24346246