### PR TITLE
Add dockerignore to reduce image build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Version control
+.git
+.gitignore
+
+# Dependency directories
+node_modules
+scripts/node_modules
+
+# Next.js build artifacts
+.next
+out
+
+# Application assets and uploads
+attached_assets
+public/tmp
+
+# Logs and runtime files
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Environment files
+.env*
+!.env.example
+
+# Editor and OS files
+.vscode
+.idea
+.DS_Store
+
+# Test coverage and build caches
+coverage
+dist
+tmp


### PR DESCRIPTION
## Summary
- add a .dockerignore file so local dependencies, build outputs, and logs are excluded from the Docker build context
- prevent large asset folders and editor artifacts from slowing down docker build context transfers

## Testing
- not run (Docker CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ceb6be84e8832facec94854c241c90