### PR TITLE
chore: streamline Prisma generation during build

### DIFF
--- a/DEPLOY-GUIDE.md
+++ b/DEPLOY-GUIDE.md
@@ -145,6 +145,9 @@ git pull origin main
 # Instalar dependências (caso tenham mudado)
 npm install --production
 
+# Se scripts de instalação forem ignorados (ex.: `npm ci --ignore-scripts`), gere o Prisma Client manualmente
+npm run db:generate
+
 # Build da aplicação
 npm run build
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "prisma generate && prisma db push && next dev -p 5000 --hostname 0.0.0.0",
-    "build": "prisma generate && next build",
+    "build": "next build",
     "start": "next start -p 5000 --hostname 0.0.0.0",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",


### PR DESCRIPTION
## Summary
- update the build script to run only the Next.js compiler, letting Prisma Client be generated during install
- document how to manually trigger `npm run db:generate` in deploy instructions when install scripts are skipped

## Testing
- npm run build *(fails: missing encrypted seed data/env needed for API routes during static generation)*

------
https://chatgpt.com/codex/tasks/task_e_68cebef41214832f9648f7dd899c55c3