### PR TITLE
chore: forward Clerk env to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 # Build
 FROM node:20 as builder
 WORKDIR /app
+
+ARG NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+
+ENV NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
+
 COPY package*.json prisma ./
 RUN npm ci || npm install
 COPY . .

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ docker compose up -d --build db web backup
 ```
 O contêiner `web` executa `./node_modules/.bin/prisma migrate deploy` automaticamente ao iniciar.
 
+> ℹ️ O build da imagem do Next.js precisa do `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`. O `docker compose` já encaminha automaticamente o valor definido no `.env`. Caso faça um `docker build` manual, lembre-se de informar o argumento:
+
+```bash
+docker build --build-arg NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="$NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY" -t financeito-web .
+```
+
 ## 8) Proxy externo (Nginx/Cloudflare)
 - No `.env`, `PUBLIC_BASE_URL` deve usar `https://`.
 - A variável `DOMAIN` foi removida; use apenas `PUBLIC_BASE_URL` para definir o domínio público.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,10 @@ services:
       retries: 5
 
   web:
-    build: .
+    build:
+      context: .
+      args:
+        NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}
     container_name: financeito-web
     restart: unless-stopped
     env_file: .env


### PR DESCRIPTION
## Summary
- expose NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY as a build argument in the Dockerfile so the Next.js build sees it
- forward the publishable key from the compose environment into the image build
- document the required build argument for manual docker build usage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cec6640574832fadc988051ce63806