### PR TITLE
Avoid double Clerk provider in auth layout

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -2,7 +2,9 @@ import '../globals.css'
 import { Inter } from 'next/font/google'
 import ThemeToggle from '@/components/theme-toggle'
 import ThemeScript from '@/components/theme-script'
-import Providers from '../providers'
+import { ThemeProvider } from '@/contexts/theme-context'
+import { ToastProvider } from '@/contexts/toast-context'
+import { ToastContainer } from '@/components/ui/toast'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -13,10 +15,13 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
         <ThemeScript />
       </head>
       <body className={`${inter.className} min-h-screen flex items-center justify-center`}>
-        <Providers>
-          <ThemeToggle className="fixed top-6 right-6 z-50" />
-          {children}
-        </Providers>
+        <ThemeProvider>
+          <ToastProvider>
+            <ThemeToggle className="fixed top-6 right-6 z-50" />
+            {children}
+            <ToastContainer />
+          </ToastProvider>
+        </ThemeProvider>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- stop wrapping auth layouts in the shared Providers component that contains a ClerkProvider
- explicitly compose the ThemeProvider, ToastProvider, and ToastContainer so auth pages still get theme and toast contexts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cef982b548832f865ba568620ef1a8