### PR TITLE
Wrap auth layout with Clerk provider

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,5 +1,6 @@
 import '../globals.css'
 import { Inter } from 'next/font/google'
+import { ClerkProvider } from '@clerk/nextjs'
 import ThemeToggle from '@/components/theme-toggle'
 import ThemeScript from '@/components/theme-script'
 import { ThemeProvider } from '@/contexts/theme-context'
@@ -15,13 +16,15 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
         <ThemeScript />
       </head>
       <body className={`${inter.className} min-h-screen flex items-center justify-center`}>
-        <ThemeProvider>
-          <ToastProvider>
-            <ThemeToggle className="fixed top-6 right-6 z-50" />
-            {children}
-            <ToastContainer />
-          </ToastProvider>
-        </ThemeProvider>
+        <ClerkProvider>
+          <ThemeProvider>
+            <ToastProvider>
+              <ThemeToggle className="fixed top-6 right-6 z-50" />
+              {children}
+              <ToastContainer />
+            </ToastProvider>
+          </ThemeProvider>
+        </ClerkProvider>
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- wrap the auth layout's providers with ClerkProvider to ensure auth pages receive Clerk context

## Testing
- `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_dummy CI=1 npm run build` *(fails: DOMException [InvalidCharacterError]: The string to be decoded is not correctly encoded.)*

------
https://chatgpt.com/codex/tasks/task_e_68cf07384990832fb1466c53caa39043