### PR TITLE
Add paginated transactions API and dashboard pagination

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -18,7 +18,11 @@ export default function Dashboard() {
   const {
     accounts,
     transactions,
+    transactionsMeta,
+    transactionPage,
+    transactionsPageSize,
     loading,
+    loadingTransactions,
     quickActions,
     quickAccessItems,
     connectDisabled,
@@ -43,6 +47,7 @@ export default function Dashboard() {
     closeManualAccountModal,
     handleSubmitManualAccount,
     handleConnect,
+    handleTransactionsPageChange,
   } = useDashboardData()
 
   return (
@@ -86,8 +91,14 @@ export default function Dashboard() {
           animate={{ opacity: 1, y: 0 }}
         >
           <TransactionsCard
-            loading={loading}
+            loading={loading || loadingTransactions}
             transactions={transactions}
+            page={transactionsMeta?.page ?? transactionPage}
+            pageSize={transactionsMeta?.pageSize ?? transactionsPageSize}
+            totalCount={transactionsMeta?.totalCount ?? transactions.length}
+            hasNextPage={Boolean(transactionsMeta?.hasNextPage)}
+            hasPreviousPage={Boolean(transactionsMeta?.hasPreviousPage)}
+            onPageChange={handleTransactionsPageChange}
             onEdit={handleOpenTransactionModal}
             onConnect={handleConnect}
             disabled={connectDisabled}

--- a/lib/transactions.ts
+++ b/lib/transactions.ts
@@ -15,6 +15,20 @@ export interface NormalizedTransaction {
   providerCategoryName?: string
 }
 
+export interface TransactionsPageMeta {
+  page: number
+  pageSize: number
+  totalCount: number
+  totalPages: number
+  hasNextPage: boolean
+  hasPreviousPage: boolean
+}
+
+export interface PaginatedTransactionsResponse {
+  data: NormalizedTransaction[]
+  meta?: Partial<TransactionsPageMeta>
+}
+
 export const parseDateValue = (value: unknown): string => {
   if (!value) {
     return new Date().toISOString()


### PR DESCRIPTION
## Summary
- add a GET handler to `/api/transactions` that validates pagination parameters and returns metadata with the results
- extend the dashboard data hook to load paginated transactions and expose pagination helpers/state to the UI
- update the transactions card to render page-aware lists and navigation controls wired to the new hook data

## Testing
- npm run test *(fails: existing Vitest alias resolution issue for @/app/... routes)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1faf3354832f927d31871d072a18