### PR TITLE
feat: support transaction deletion

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -38,6 +38,7 @@ export default function Dashboard() {
     transactionFormData,
     loadingTransactionForm,
     savingTransaction,
+    handleDeleteTransaction,
     manualAccountOptions,
     manualAccountModalOpen,
     savingManualAccount,
@@ -100,6 +101,7 @@ export default function Dashboard() {
             hasPreviousPage={Boolean(transactionsMeta?.hasPreviousPage)}
             onPageChange={handleTransactionsPageChange}
             onEdit={handleOpenTransactionModal}
+            onDelete={handleDeleteTransaction}
             onConnect={handleConnect}
             disabled={connectDisabled}
           />
@@ -135,6 +137,7 @@ export default function Dashboard() {
           transaction={transactionFormData ?? undefined}
           onSubmit={handleSubmitTransaction}
           onCancel={closeTransactionModal}
+          onDelete={handleDeleteTransaction}
           loading={loadingTransactionForm}
           submitting={savingTransaction}
           manualAccounts={manualAccountOptions}


### PR DESCRIPTION
## Summary
- add a DELETE handler for transactions that validates ownership, removes manual balances, and deletes the record
- expose a dashboard hook action and UI affordances (list + modal) to confirm and trigger deletions

## Testing
- `npm run test` *(fails: existing vitest alias resolution error for user dropdown routes)*

------
https://chatgpt.com/codex/tasks/task_e_68cf22eee504832fa0311b457dc0ff4e